### PR TITLE
Fix mongodb error waiting for service.

### DIFF
--- a/modules/pulp/manifests/init.pp
+++ b/modules/pulp/manifests/init.pp
@@ -94,6 +94,9 @@ class pulp (
     ssl_cert_name           => 'broker',
     user_groups             => $pulp::user_groups
   } ~>
+  # Make sure we install the mongodb client, used by service-wait to check
+  # that the server is up.
+  class {'::mongodb::client':} ~>
   class { 'pulp::install':
     require => [Class['mongodb'], Class['qpid']]
   } ~>


### PR DESCRIPTION
Fixes https://github.com/Katello/katello-installer/issues/38.

The service wait script for mongo attempts to use the mongodb client to check
if the server is up yet. However at the point that it runs, the client is not
yet installed. Because we redirect all output to /dev/null, the error is just
silently swallowed and we sit there waiting for a successful run until the max
timeout is reached.

Instead we install the mongodb client before the pulp module tries to trigger
the service-wait. Now after the journal file is created (which takes a few
seconds) the installer will resume much more quickly and not show any mongodb
errors.
