### PR TITLE
Fixing templates to refer to variables properly.

### DIFF
--- a/modules/certs/templates/rhsm-katello-reconfigure.erb
+++ b/modules/certs/templates/rhsm-katello-reconfigure.erb
@@ -16,7 +16,7 @@
 # Configures rhsm on client. Called from the certificate RPM.
 #
 
-KATELLO_SERVER=<%= has_variable?("fqdn") ? fqdn : hostname %>
+KATELLO_SERVER=<%= has_variable?("fqdn") ? @fqdn : @hostname %>
 PORT=443
 <% if scope.lookupvar("katello::params::deployment") == 'katello' %>
 BASEURL=https://$KATELLO_SERVER/pulp/repos

--- a/modules/pulp/templates/etc/pulp/server.conf.erb
+++ b/modules/pulp/templates/etc/pulp/server.conf.erb
@@ -37,7 +37,7 @@ operation_retries: 2
 # debugging_mode: boolean; toggles Pulp's debugging capabilities
 
 [server]
-server_name: <%= (has_variable?("fqdn") ? fqdn : hostname).downcase %>
+server_name: <%= (has_variable?("fqdn") ? @fqdn : @hostname).downcase %>
 key_url: /pulp/gpg
 ks_url: /pulp/ks
 default_login: <%= @default_login %>
@@ -279,7 +279,7 @@ dispatch_interval: 30
 # sync_weight: concurrency weight of repository sync tasks
 
 [tasks]
-concurrency_threshold: <%= processorcount.to_i + 1 %>
+concurrency_threshold: <%= @processorcount.to_i + 1 %>
 dispatch_interval: 0.5
 archived_call_lifetime: 48
 consumer_content_weight: 0


### PR DESCRIPTION
While installing katello 'community' nighty today I noticed a few errors
related to how certain variables were being refered to in a couple of
templates:

``` bash
Variable access via 'fqdn' is deprecated. Use '@fqdn' instead.
template[/usr/share/katello-installer/modules/certs/templates/rhsm-katello-reconfigure.erb]:19
Variable access via 'fqdn' is deprecated. Use '@fqdn' instead.
template[/usr/share/katello-installer/modules/pulp/templates/etc/pulp/server.conf.erb]:40
Variable access via 'processorcount' is deprecated. Use
'@processorcount' instead.
template[/usr/share/katello-installer/modules/pulp/templates/etc/pulp/server.conf.erb]:282
```

This pull request should fix these variables but it does not, however,
solve the last of the issues:

``` bash
ruby 1.8.7 (2011-06-30 patchlevel 352) sh: line 1:  3366 Done
echo '$kafo_config_file="/etc/katello-installer/katello_installer.yaml"
$kafo_answer_file="/tmp/kafo_answers_983597.yaml"  include
kafo_configure'

3367 Aborted                 (core dumped) |
RUBYLIB=/usr/lib/ruby/gems/1.8/gems/kafo-0.5.3/lib/kafo/../..//modules:
puppet apply --verbose --debug --trace --color=false --show_diff
--detailed-exitcodes --modulepath
/usr/share/katello-installer/modules:/usr/lib/ruby/gems/1.8/gems/kafo-0.5.3/modules

Puppet has finished, bye!
```
