### PR TITLE
Fixes #5012: Postgresql role already exists errors.

### DIFF
--- a/modules/candlepin/manifests/init.pp
+++ b/modules/candlepin/manifests/init.pp
@@ -84,10 +84,10 @@ class candlepin (
   $weburl = "https://${::fqdn}/${candlepin::deployment_url}/distributors?uuid="
   $apiurl = "https://${::fqdn}/${candlepin::deployment_url}/api/distributors/"
 
-  class { 'candlepin::install': } ~>
-  class { 'candlepin::config': } ~>
-  class { 'candlepin::database': } ~>
-  class { 'candlepin::service': } ~>
+  class { 'candlepin::install': } ->
+  class { 'candlepin::config': } ->
+  class { 'candlepin::database': } ->
+  class { 'candlepin::service': } ->
   Class['candlepin']
 
 }

--- a/modules/katello_devel/manifests/init.pp
+++ b/modules/katello_devel/manifests/init.pp
@@ -47,13 +47,13 @@ class katello_devel (
 
   $group = $user
 
-  Class['certs'] ~>
-  class { 'certs::apache': } ~>
-  class { 'katello_devel::apache': } ~>
-  class { 'certs::katello': } ~>
-  class { 'katello_devel::install': } ~>
-  class { 'katello_devel::config': } ~>
-  class { 'katello_devel::database': } ~>
+  Class['certs'] ->
+  class { 'certs::apache': } ->
+  class { 'katello_devel::apache': } ->
+  class { 'certs::katello': } ->
+  class { 'katello_devel::install': } ->
+  class { 'katello_devel::config': } ->
+  class { 'katello_devel::database': } ->
   class { 'katello_devel::setup':
     require => [
       Class['pulp'],
@@ -62,8 +62,8 @@ class katello_devel (
     ]
   }
 
-  Class['certs'] ~>
-  class { 'certs::candlepin': } ~>
+  Class['certs'] ->
+  class { 'certs::candlepin': } ->
   class { 'candlepin':
     user_groups       => $katello_devel::group,
     oauth_key         => $katello_devel::oauth_key,
@@ -75,11 +75,11 @@ class katello_devel (
     require           => Class['katello_devel::database']
   }
 
-  Class['certs'] ~>
+  Class['certs'] ->
   class { 'certs::qpid':
     require => Class['qpid::install']
-  } ~>
-  class { 'certs::pulp_parent': } ~>
+  } ->
+  class { 'certs::pulp_parent': } ->
   class { 'pulp':
     oauth_key                   => $katello_devel::oauth_key,
     oauth_secret                => $katello_devel::oauth_secret,


### PR DESCRIPTION
Problem appears to have been related to use of puppet ~> notification arrow,
which seems to cause the postgresql module to attempt to re-create the roles
again. In this case we do not appear to want or need notifications sent if a
chained task makes any changes (which it almost certainly will running this
installer the first time). Switching to the simpler -> chaining arrow corrects
the problem and maintains dependency ordering.

WARNING: I am not entirely sure what I'm doing here. However looking at the puppet docs I don't think the ~> was warranted and likely the result of some copy paste. There are probably a lot of other areas where it's being used unnecessarily. 

http://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html#chaining-arrows

Let me know what you think.
