### PR TITLE
Refs #4244: Prevent seg fault on Ruby 1.8.7.

### DIFF
--- a/config/answers.katello-installer.yaml
+++ b/config/answers.katello-installer.yaml
@@ -29,10 +29,13 @@ foreman::plugin::puppetdb: false
 foreman::plugin::setup: false
 foreman::plugin::templates: false
 
-foreman::compute::ec2: true
-foreman::compute::gce: true
-foreman::compute::libvirt: true
-foreman::compute::openstack: false
-foreman::compute::ovirt: true
-foreman::compute::rackspace: false
-foreman::compute::vmware: true
+# Issue #4244 - Commenting these out due to the seg fault
+# caused on Ruby 1.8.7, the Katello RPM ensures these
+# are installed instead
+#foreman::compute::ec2: true
+#foreman::compute::gce: true
+#foreman::compute::libvirt: true
+#foreman::compute::openstack: false
+#foreman::compute::ovirt: true
+#foreman::compute::rackspace: false
+#foreman::compute::vmware: true


### PR DESCRIPTION
Commenting out the use of the compute resources in order to prevent
seg faults on installation. These are instead required as RPMs by
the Katello RPM package thus achieving the same functionality.
