### PR TITLE
Fixes #6278 : Add additional checks to the installer.

### DIFF
--- a/checks/disk_size.rb
+++ b/checks/disk_size.rb
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+SIZE = %q(The installation requires at least 5G of storage.) 
+
+def error_exit(message, code)
+  $stderr.puts message
+  exit code
+end
+
+begin
+    total_space = `df -H --total`.split("\n")[-1].split()[3]
+
+    # Look for a value greater than 4GB
+    error_exit(SIZE, 1) unless total_space.include?("G")
+    error_exit(SIZE, 2) if total_space.gsub("G","").to_i < 5
+rescue
+    # Eat the exception and continue
+end

--- a/checks/java.rb
+++ b/checks/java.rb
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+
+JAVA_VERSION = %q(An OpenJDK version of Java greater than 1.7 should be installed)
+
+OPENJDK = %q(A version of java which is not OpenJDK is installed.
+
+Please install an OpenJDK version greater than 1.7)
+ 
+
+def error_exit(message, code)
+  $stderr.puts message
+  exit code
+end
+
+java_version_string = `/usr/bin/java -version 2>&1`
+java_version = java_version_string.split("\n")[0].split('"')[1]
+
+# Check that OpenJDK 1.7 or higher is installed if any java is installed
+if java_version
+    error_exit(JAVA_VERSION, 1) if java_version < "1.7"
+    error_exit(OPENJDK, 2) unless java_version_string.include? "OpenJDK"
+end


### PR DESCRIPTION
This adds two new checks. One is using the output of java --version
to ensure the version is at least 1.7 and is the OpenJDK. The second
is looking for total available disk space of at least 5 GB. This does
not really ensure a space issue, but it is is a good first cut.
