### PR TITLE
Fixes #4650 - sets consumer rpm in katello.yml

### DIFF
--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -30,7 +30,7 @@ GIT
 GIT
   remote: https://github.com/Katello/puppet-certs
   ref: master
-  sha: 22fb55c34a04ee74f75e57eba1d7f321e967a327
+  sha: 06752315baeda85f6557186afe63444f7225c0e5
   specs:
     katello/certs (0.0.1)
 
@@ -51,7 +51,7 @@ GIT
 GIT
   remote: https://github.com/Katello/puppet-katello
   ref: master
-  sha: 386811653ba1ab03feb722cbe027ac7735b92f97
+  sha: a3c6dac978e3dc4993c90876fd0ffd244d9f217f
   specs:
     katello/katello (0.0.1)
 

--- a/modules/certs/manifests/katello.pp
+++ b/modules/certs/manifests/katello.pp
@@ -1,11 +1,19 @@
 # Katello specific certs settings
-class certs::katello ($hostname = $fqdn, $deployment_url = undef){
+class certs::katello (
+  $hostname                      = $fqdn,
+  $deployment_url                = undef,
+  $candlepin_cert_rpm_alias_filename = undef
+  ){
+
+  $candlepin_cert_rpm_alias = $candlepin_cert_rpm_alias_filename ? {
+    undef   => "${$certs::default_ca_name}-consumer-latest.noarch.rpm",
+    default => $candlepin_cert_rpm_alias_filename,
+  }
 
   $katello_www_pub_dir            = '/var/www/html/pub'
   $candlepin_consumer_name        = "${$certs::default_ca_name}-consumer-${::fqdn}"
   $candlepin_consumer_summary     = "Subscription-manager consumer certificate for Katello instance ${::fqdn}"
   $candlepin_consumer_description = 'Consumer certificate and post installation script that configures rhsm.'
-
   file { $katello_www_pub_dir:
     ensure => directory,
     owner  => 'apache',
@@ -25,7 +33,7 @@ class certs::katello ($hostname = $fqdn, $deployment_url = undef){
     creates   => "${katello_www_pub_dir}/${candlepin_consumer_name}-1.0-1.noarch.rpm",
     logoutput => 'on_failure';
   } ~>
-  file { "${katello_www_pub_dir}/${$certs::default_ca_name}-consumer-latest.noarch.rpm":
+  file { "${katello_www_pub_dir}/${candlepin_cert_rpm_alias}":
     ensure  => 'link',
     target  => "${katello_www_pub_dir}/${candlepin_consumer_name}-1.0-1.noarch.rpm",
   }

--- a/modules/certs/templates/rhsm-katello-reconfigure.erb
+++ b/modules/certs/templates/rhsm-katello-reconfigure.erb
@@ -58,7 +58,7 @@ else
 fi
 
 if grep --quiet full_refresh_on_yum $CFG; then
-  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g"
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $CFG
 else
   full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
   sed -i "s/baseurl.*/&\n\n$full_refresh_config/g" $CFG

--- a/modules/katello/templates/katello.yml.erb
+++ b/modules/katello/templates/katello.yml.erb
@@ -25,6 +25,8 @@ common:
   use_ssl: true
   use_foreman: <%= scope.lookupvar("katello::params::use_foreman") %>
 
+  consumer_cert_rpm: <%= scope.lookupvar("certs::katello::candlepin_cert_rpm_alias") %>
+
   post_sync_url: https://localhost<%= scope.lookupvar("katello::params::deployment_url") %>/api/v2/repositories/sync_complete?token=<%= scope.lookupvar("post_sync_token") %>
 
   candlepin:


### PR DESCRIPTION
Sets the candlepin consumer rpm name in katello's config file
(katello.yml).
