### PR TITLE
Fixes #7077/BZ1127242: generate random password for pulp user.

### DIFF
--- a/modules/pulp/manifests/params.pp
+++ b/modules/pulp/manifests/params.pp
@@ -21,7 +21,7 @@ class pulp::params {
   $qpid_ssl_cert_password_file = undef
 
   $default_login = 'admin'
-  $default_password = 'admin'
+  $default_password = random_password(32)
 
   $repo_auth = true
 


### PR DESCRIPTION
Generate a random password instead of using the password "admin"
for the default pulp user.

http://projects.theforeman.org/issues/7077
https://bugzilla.redhat.com/show_bug.cgi?id=1127242
