### PR TITLE
fixes #7723 - pull in puppet-foreman which does not install mod_lookup_identity-selinux on RHEL 7.

### DIFF
--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -148,7 +148,7 @@ GIT
 GIT
   remote: https://github.com/theforeman/puppet-foreman
   ref: master
-  sha: 941a9e8ef537d9b5ed007806f93211f540f50798
+  sha: 0f64157746c7d51820b4b308f6a5cd0885254edc
   specs:
     theforeman-foreman (2.1.2)
       puppetlabs-apache (< 2.0.0, >= 1.0.0)


### PR DESCRIPTION
Of course, if we change the Puppetfile.lock, we could go one commit further in puppet-foreman and use the one defining the 2.2.0 release -- ca2a022e198728e68a1dafb951b890765f54b714.
