### PR TITLE
Fixes #7882 - Added support for Oracle Linux

### DIFF
--- a/modules/katello/manifests/install.pp
+++ b/modules/katello/manifests/install.pp
@@ -4,6 +4,7 @@ class katello::install {
   $os = $::operatingsystem ? {
     'RedHat' => 'RHEL',
     'CentOS' => 'RHEL',
+    'OracleLinux' => 'RHEL',
     default  => 'Fedora'
   }
 

--- a/modules/katello/manifests/params.pp
+++ b/modules/katello/manifests/params.pp
@@ -1,7 +1,6 @@
 # Katello Default Params
 class katello::params {
-
-  if ($::operatingsystem == 'RedHat' or $::operatingsystem == 'CentOS'){
+  if ($::operatingsystem == 'RedHat' or $::operatingsystem == 'CentOS' or $::operatingsystem == 'OracleLinux') {
     $scl_prefix = 'ruby193-'
     $scl_root = '/opt/rh/ruby193/root'
   } else {
@@ -14,8 +13,7 @@ class katello::params {
 
   if file_exists('/usr/sbin/tomcat') and !file_exists('/usr/sbin/tomcat6') {
     $tomcat = 'tomcat'
-  }
-  else {
+  } else {
     $tomcat = 'tomcat6'
   }
 
@@ -29,8 +27,8 @@ class katello::params {
   $user = 'foreman'
   $group = 'foreman'
   $user_groups = 'foreman'
-  $config_dir  = '/etc/foreman/plugins'
-  $log_dir     = '/var/log/foreman/plugins'
+  $config_dir = '/etc/foreman/plugins'
+  $log_dir = '/var/log/foreman/plugins'
 
   # sysconfig settings
   $job_workers = 1
@@ -49,8 +47,8 @@ class katello::params {
 
   # Subsystems settings
   $candlepin_url = 'https://localhost:8443/candlepin'
-  $pulp_url      = subsystem_url('pulp/api/v2/')
-  $foreman_url   = subsystem_url('foreman')
+  $pulp_url = subsystem_url('pulp/api/v2/')
+  $foreman_url = subsystem_url('foreman')
 
   # database reinitialization flag
   $reset_data = 'NONE'

--- a/modules/katello_devel/manifests/install/repos/yum.pp
+++ b/modules/katello_devel/manifests/install/repos/yum.pp
@@ -13,6 +13,7 @@ define katello_devel::install::repos::yum ($repo, $gpgcheck) {
   }
   $os = $::operatingsystem ? {
     'CentOS'  => 'RHEL',
+    'OracleLinux'  => 'RHEL',
     'RHEL'    => 'RHEL',
     'Fedora'  => 'Fedora'
   }


### PR DESCRIPTION
In the katello manifest there is a logic to use the relevant package names (including the packages from SCL) based upon the fact "operatingsystem". As there is no separate SCL yum repo for OracleLinux, the installation of katello fails due to lookup of "rubygems-katello" instead of "ruby193-rubygems-katello". I have added an extra option for OracleLinux inline with the existing options of Centos and RHEL. Also as Geppetto has automatically formatted the code the change set appears to be the entire file instead of the lines that were edited.
