### PR TITLE
1153742: Disable SSLv3 in tomcat

### DIFF
--- a/modules/candlepin/templates/tomcat/server.xml.erb
+++ b/modules/candlepin/templates/tomcat/server.xml.erb
@@ -88,7 +88,9 @@
 
     <Connector port="8443" protocol="HTTP/1.1" SSLEnabled="true"
                maxThreads="150" scheme="https" secure="true"
-               clientAuth="want" SSLProtocol="TLS"
+               clientAuth="want"
+               sslEnabledProtocol="TLSv1.2,TLSv1.1,TLSv1"
+               SSLProtocol="TLS"
                keystoreFile="conf/keystore"
                truststoreFile="conf/keystore"
                keystorePass="<%= scope.lookupvar("candlepin::keystore_password") %>"

--- a/modules/candlepin/templates/tomcat6/server.xml.erb
+++ b/modules/candlepin/templates/tomcat6/server.xml.erb
@@ -90,6 +90,7 @@
     <Connector port="8443" protocol="HTTP/1.1" SSLEnabled="true"
                maxThreads="150" scheme="https" secure="true"
                clientAuth="want" SSLProtocol="TLS"
+               sslEnabledProtocol="TLSv1.2,TLSv1.1,TLSv1"
                keystoreFile="conf/keystore"
                truststoreFile="conf/keystore"
                keystorePass="<%= scope.lookupvar("candlepin::keystore_password") %>"


### PR DESCRIPTION
Only enable SSL protocols TLSv1.2, TLSv1.2, TLSv1
to mitigate the SSLv3 poodle attach (CVE-2014-3566)

TLSv1 has to stay enabled to support existing deployed
clients (python-rhsm, subscription-manager) that only
support TLSv1.
