### PR TITLE
Fixes #6927 - make the subscription identity check language independent

### DIFF
--- a/hooks/pre_validations/10-check_capsule_pulp.rb
+++ b/hooks/pre_validations/10-check_capsule_pulp.rb
@@ -13,7 +13,7 @@ if param('capsule', 'pulp') && param('capsule', 'pulp').value
     error "the pulp node can't be installed on a machine with IPA"
   end
 
-  unless system("subscription-manager identity | grep identity && ! grep -q subscription.rhn.redhat.com /etc/rhsm/rhsm.conf")
+  unless system("subscription-manager identity &>/dev/null && ! grep -q subscription.rhn.redhat.com /etc/rhsm/rhsm.conf &> /dev/null")
     error "The system has to be registered to a Katello instance before installing the node"
   end
 end


### PR DESCRIPTION
Check exit status of `subscription-manager identity` should be enough to find 
out if the system was registered or not.
