### PR TITLE
fixes #8378 - set umask to required value for installaton

### DIFF
--- a/hooks/pre/16-set_umask.rb
+++ b/hooks/pre/16-set_umask.rb
@@ -1,0 +1,4 @@
+if File.umask != 0022
+  old = File.umask(0022)
+  logger.info "Set umask to 0022 for installation, former umask was #{old.to_s(8).rjust(4, '0')}"
+end


### PR DESCRIPTION
A umask other than 0022 causes installation failures, so we set it temporarily for the install.
