### PR TITLE
Improved java check error messages

### DIFF
--- a/hooks/pre/15-check_java.rb
+++ b/hooks/pre/15-check_java.rb
@@ -1,9 +1,15 @@
-JAVA_VERSION = %q(An OpenJDK version of Java greater than 1.7 should be installed.  For more details on the version currently installed, run 'java -version')
+JAVA_VERSION = %q(An OpenJDK version of Java greater than 1.7 should be installed. For more
+details on the version currently installed, run 'java -version')
 
 OPENJDK = %q(A version of java which is not OpenJDK is installed.
 
-Please install an OpenJDK version greater than 1.7.  For more details on the version currently installed, run 'java -version')
- 
+Please install an OpenJDK version greater than 1.7 and make sure it
+was set as the default java using
+
+  alternatives --config java
+
+For more details on the version currently installed, run 'java -version'.)
+
 def module_enabled?(name)
   mod = @kafo.module(name)
   return false if mod.nil?


### PR DESCRIPTION
Our error messages were not hard-wrapped.

Also added info about how to set default Java in case both OpenJDK and GCJ were
installed (and GCJ as later package):

    alternatives --config java