### PR TITLE
fixes #9075 - hooks_dir should be hook_dirs

### DIFF
--- a/config/capsule-certs-generate.yaml
+++ b/config/capsule-certs-generate.yaml
@@ -22,7 +22,7 @@
 :answer_file: ./config/answers.capsule-certs-generate.yaml
 :installer_dir: .
 :modules_dir: "./modules"
-:hooks_dir: "./hooks"
+:hook_dirs: ["./hooks"]
 :default_values_dir: ./config
 :dont_save_answers: true
 :mapping:

--- a/config/capsule-installer.yaml
+++ b/config/capsule-installer.yaml
@@ -1,4 +1,4 @@
---- 
+---
   :log_dir: /var/log/capsule-installer
   :log_name: capsule-installer.log
   :log_level: :debug
@@ -7,7 +7,7 @@
   :installer_dir: "."
   :default_values_dir: "./config"
   :modules_dir: "./modules"
-  :hooks_dir: "./hooks"
+  :hook_dirs: ["./hooks"]
   :colors: true
   :order:
     - certs

--- a/config/katello-installer.yaml
+++ b/config/katello-installer.yaml
@@ -6,7 +6,7 @@
   :answer_file: "./config/answers.katello-installer.yaml"
   :installer_dir: "."
   :modules_dir: "./modules"
-  :hooks_dir: "./hooks"
+  :hook_dirs: ["./hooks"]
   :default_values_dir: "./config"
   :colors: true
   :password: l7VtnWiPeKe412o2CVBM6yVbTkKGh6L_CKx4_zBkmUE

--- a/config/sam-installer.yaml
+++ b/config/sam-installer.yaml
@@ -6,7 +6,7 @@
   :answer_file: "./config/answers.sam-installer.yaml"
   :installer_dir: "."
   :modules_dir: "./modules"
-  :hooks_dir: "./hooks"
+  :hook_dirs: ["./hooks"]
   :default_values_dir: "./config"
   :colors: true
   :password: l7VtnWiPeKe412o2CVBM6yVbTkKGh6L_CKx4_zBkmUE

--- a/katello-installer.spec
+++ b/katello-installer.spec
@@ -129,7 +129,7 @@ sed -ri 'sX\:installer_dir.*$X:installer_dir: %{_datadir}/sam-installerXg' confi
 sed -ri 'sX\:installer_dir.*$X:installer_dir: %{_datadir}/capsule-installerXg' config/capsule-installer.yaml
 
 sed -ri 'sX\:modules_dir.*$X:modules_dir: %{_datadir}/katello-installer/modulesXg' config/*
-sed -ri 'sX\:hooks_dir.*$X:hooks_dir: %{_datadir}/katello-installer/hooksXg' config/*
+sed -ri 'sX\:hook_dirs.*$X:hook_dirs: \["%{_datadir}/katello-installer/hooks"\]Xg' config/*
 
 %install
 install -d -m0755 %{buildroot}%{_sysconfdir}/katello-installer


### PR DESCRIPTION
See: https://github.com/theforeman/kafo/commit/1185cf813a392c63029a4ddcd4beca28b9e88034.  

capsule-installer hooks are in a common directory `/usr/share/katello-installer` and aren't being loaded.  It was working before because Kafo also looks in the installer directory itself, but now these are separated.

