### PR TITLE
Fixes #9809: Use 'yum localinstall' to install sub-man as well.

### DIFF
--- a/hooks/post/10-post_install.rb
+++ b/hooks/post/10-post_install.rb
@@ -50,7 +50,7 @@ MSG
      parameters, see <%= color("capsule-installer --help", :info) %> and
      documentation for more info on setting up additional services):
 
-  rpm -Uvh http://#{fqdn}/pub/katello-ca-consumer-latest.noarch.rpm
+  yum -y localinstall http://#{fqdn}/pub/katello-ca-consumer-latest.noarch.rpm
   subscription-manager register --org "<%= color('#{org}', :info) %>"
   capsule-installer --parent-fqdn          "<%= "#{fqdn}" %>"\\
                     --register-in-foreman  "true"\\


### PR DESCRIPTION
On non-rhel systems, users would need to ensure subscription-manager
got installed and then run the bootstrap RPM command. This will
change it such that the bootstrap RPM and it's dependencies are
attempted to be installed more cleanly for users.