### PR TITLE
Fixes #9888 - require openssl for katello-installer-base

### DIFF
--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -45,12 +45,12 @@ GIT
 GIT
   remote: https://github.com/Katello/puppet-certs
   ref: master
-  sha: a5255986f1491513eb6eed6d0c9d7ca20ae4693d
+  sha: cec063aad80d67afe28dd50ac8134a15338af392
   specs:
     katello-certs (0.1.0)
       katello-common (>= 0.0.1)
       puppetlabs-stdlib (>= 1.0.0)
-      theforeman-foreman (>= 1.5.0)
+      theforeman-foreman (>= 2.0.0)
 
 GIT
   remote: https://github.com/Katello/puppet-common
@@ -202,7 +202,7 @@ GIT
 GIT
   remote: https://github.com/puppetlabs/puppetlabs-postgresql
   ref: master
-  sha: 0438db2f017d60e65e31b3dda066cbdfb2a0c6b9
+  sha: f3a17066d17a88bb08fb167144e98a1116f78990
   specs:
     puppetlabs-postgresql (4.2.0)
       puppetlabs-apt (< 2.0.0, >= 1.1.0)

--- a/katello-installer.spec
+++ b/katello-installer.spec
@@ -17,6 +17,7 @@ Obsoletes: katello-installer < 2.1.0
 Requires: %{?scl_prefix}rubygem-kafo
 Requires: %{?scl_prefix}rubygem-apipie-bindings >= 0.0.6
 Requires: foreman-selinux
+Requires: openssl
 
 %package -n katello-installer
 Summary: Puppet-based installer for Katello Server

--- a/modules/certs/manifests/init.pp
+++ b/modules/certs/manifests/init.pp
@@ -120,7 +120,7 @@ class certs (
   $ca_key = "${certs::pki_dir}/private/${default_ca_name}.key"
   $ca_cert = "${certs::pki_dir}/certs/${default_ca_name}.crt"
   $ca_cert_stripped = "${certs::pki_dir}/certs/${default_ca_name}-stripped.crt"
-  $ca_key_password = cache_data('ca_key_password', generate_password())
+  $ca_key_password = cache_data('ca_key_password', random_password(24))
   $ca_key_password_file = "${certs::pki_dir}/private/${default_ca_name}.pwd"
 
   $katello_server_ca_cert = "${certs::pki_dir}/certs/${server_ca_name}.crt"

--- a/modules/certs/metadata.json
+++ b/modules/certs/metadata.json
@@ -14,7 +14,7 @@
     },
     {
        "name": "theforeman-foreman",
-       "version_requirement": ">= 1.5.0"
+       "version_requirement": ">= 2.0.0"
     },
     {
        "name": "katello-common",

--- a/modules/postgresql/.sync.yml
+++ b/modules/postgresql/.sync.yml
@@ -1,9 +1,9 @@
 ---
 .travis.yml:
   extras:
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.5" STRICT_VARIABLES="yes"
-  - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3.5" STRICT_VARIABLES="yes"
+  - rvm: 1.8.7
+    env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.6.0"
+  - rvm: 1.8.7
+    env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.7.0"
 spec/spec_helper.rb:
   unmanaged: true

--- a/modules/postgresql/.travis.yml
+++ b/modules/postgresql/.travis.yml
@@ -1,21 +1,28 @@
 ---
+sudo: false
 language: ruby
 bundler_args: --without system_tests
 script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake spec SPEC_OPTS='--format documentation'"
 matrix:
   fast_finish: true
   include:
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3.4.0"
+  - rvm: 1.8.7
+    env: PUPPET_GEM_VERSION="~> 3.0"
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3.0"
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
+  - rvm: 2.1.5
+    env: PUPPET_GEM_VERSION="~> 3.0"
+  - rvm: 2.1.5
+    env: PUPPET_GEM_VERSION="~> 3.4.0"
+  - rvm: 2.1.5
+    env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
   - rvm: 1.8.7
     env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.6.0"
   - rvm: 1.8.7
     env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.7.0"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.0"
-  - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3.0"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.5" STRICT_VARIABLES="yes"
-  - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3.5" STRICT_VARIABLES="yes"
 notifications:
   email: false

--- a/modules/postgresql/Gemfile
+++ b/modules/postgresql/Gemfile
@@ -1,11 +1,8 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :development, :unit_tests do
-  gem 'rake',                    :require => false
   gem 'rspec-core', '3.1.7',     :require => false
-  gem 'rspec-puppet', '~> 1.0',  :require => false
   gem 'puppetlabs_spec_helper',  :require => false
-  gem 'puppet-lint',             :require => false
   gem 'simplecov',               :require => false
   gem 'puppet_facts',            :require => false
   gem 'json',                    :require => false

--- a/modules/postgresql/Rakefile
+++ b/modules/postgresql/Rakefile
@@ -1,7 +1,7 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 
-PuppetLint.configuration.fail_on_warnings
+PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.send('relative')
 PuppetLint.configuration.send('disable_80chars')
 PuppetLint.configuration.send('disable_class_inherits_from_params_class')

--- a/modules/postgresql/manifests/server/extension.pp
+++ b/modules/postgresql/manifests/server/extension.pp
@@ -5,16 +5,29 @@ define postgresql::server::extension (
   $package_name = undef,
   $package_ensure = undef,
 ) {
+  $user          = $postgresql::server::user
+  $group         = $postgresql::server::group
+  $psql_path     = $postgresql::server::psql_path
+  $port          = $postgresql::server::port
+
+  # Set the defaults for the postgresql_psql resource
+  Postgresql_psql {
+    psql_user  => $user,
+    psql_group => $group,
+    psql_path  => $psql_path,
+    port       => $port,
+  }
+
   case $ensure {
     'present': {
-      $command = "CREATE EXTENSION ${name}"
+      $command = "CREATE EXTENSION \"${name}\""
       $unless_comp = '='
       $package_require = undef
       $package_before = Postgresql_psql["Add ${title} extension to ${database}"]
     }
 
     'absent': {
-      $command = "DROP EXTENSION ${name}"
+      $command = "DROP EXTENSION \"${name}\""
       $unless_comp = '!='
       $package_require = Postgresql_psql["Add ${title} extension to ${database}"]
       $package_before = undef

--- a/modules/postgresql/manifests/server/initdb.pp
+++ b/modules/postgresql/manifests/server/initdb.pp
@@ -9,6 +9,16 @@ class postgresql::server::initdb {
   $locale       = $postgresql::server::locale
   $group        = $postgresql::server::group
   $user         = $postgresql::server::user
+  $psql_path    = $postgresql::server::psql_path
+  $port         = $postgresql::server::port
+
+  # Set the defaults for the postgresql_psql resource
+  Postgresql_psql {
+    psql_user  => $user,
+    psql_group => $group,
+    psql_path  => $psql_path,
+    port       => $port,
+  }
 
   # Make sure the data directory exists, and has the correct permissions.
   file { $datadir:

--- a/modules/postgresql/manifests/validate_db_connection.pp
+++ b/modules/postgresql/manifests/validate_db_connection.pp
@@ -40,14 +40,14 @@ define postgresql::validate_db_connection(
     undef   => undef,
     default => "PGPASSWORD=${database_password}",
   }
-  $cmd = join([$cmd_init, $cmd_host, $cmd_user, $cmd_port, $cmd_dbname])
+  $cmd = join([$cmd_init, $cmd_host, $cmd_user, $cmd_port, $cmd_dbname], ' ')
   $validate_cmd = "/usr/local/bin/validate_postgresql_connection.sh ${sleep} ${tries} '${cmd}'"
 
   # This is more of a safety valve, we add a little extra to compensate for the
   # time it takes to run each psql command.
   $timeout = (($sleep + 2) * $tries)
 
-  $exec_name = "validate postgres connection for ${database_host}/${database_name}"
+  $exec_name = "validate postgres connection for ${database_username}@${database_host}:${database_port}/${database_name}"
   exec { $exec_name:
     command     => "echo 'Unable to connect to defined database using: ${cmd}' && false",
     unless      => $validate_cmd,

--- a/modules/postgresql/spec/unit/defines/server/extension_spec.rb
+++ b/modules/postgresql/spec/unit/defines/server/extension_spec.rb
@@ -29,7 +29,7 @@ describe 'postgresql::server::extension', :type => :define do
     it {
       is_expected.to contain_postgresql_psql('Add postgis extension to template_postgis').with({
         :db      => 'template_postgis',
-        :command => 'CREATE EXTENSION postgis',
+        :command => 'CREATE EXTENSION "postgis"',
         :unless  => "SELECT t.count FROM (SELECT count(extname) FROM pg_extension WHERE extname = 'postgis') as t WHERE t.count = 1",
       }).that_requires('Postgresql::Server::Database[template_postgis]')
     }
@@ -57,7 +57,7 @@ describe 'postgresql::server::extension', :type => :define do
     it {
       is_expected.to contain_postgresql_psql('Add postgis extension to template_postgis').with({
         :db      => 'template_postgis',
-        :command => 'DROP EXTENSION postgis',
+        :command => 'DROP EXTENSION "postgis"',
         :unless  => "SELECT t.count FROM (SELECT count(extname) FROM pg_extension WHERE extname = 'postgis') as t WHERE t.count != 1",
       }).that_requires('Postgresql::Server::Database[template_postgis]')
     }
@@ -77,7 +77,7 @@ describe 'postgresql::server::extension', :type => :define do
       it {
         is_expected.to contain_postgresql_psql('Add postgis extension to template_postgis').with({
           :db      => 'template_postgis',
-          :command => 'DROP EXTENSION postgis',
+          :command => 'DROP EXTENSION "postgis"',
           :unless  => "SELECT t.count FROM (SELECT count(extname) FROM pg_extension WHERE extname = 'postgis') as t WHERE t.count != 1",
         }).that_requires('Postgresql::Server::Database[template_postgis]')
       }

--- a/modules/postgresql/spec/unit/defines/server/pg_hba_rule_spec.rb
+++ b/modules/postgresql/spec/unit/defines/server/pg_hba_rule_spec.rb
@@ -110,7 +110,7 @@ describe 'postgresql::server::pg_hba_rule', :type => :define do
         }
       end
       it 'should fail parsing when type is not valid' do
-        expect {subject}.to raise_error(Puppet::Error,
+        expect { catalogue }.to raise_error(Puppet::Error,
           /The type you specified \[invalid\] must be one of/)
       end
     end
@@ -134,7 +134,7 @@ describe 'postgresql::server::pg_hba_rule', :type => :define do
       end
 
       it 'should fail parsing when auth_method is not valid' do
-        expect {subject}.to raise_error(Puppet::Error,
+        expect { catalogue }.to raise_error(Puppet::Error,
           /The auth_method you specified \[invalid\] must be one of/)
       end
     end
@@ -161,7 +161,7 @@ describe 'postgresql::server::pg_hba_rule', :type => :define do
       end
 
       it 'should fail parsing when auth_method is not valid' do
-        expect {subject}.to raise_error(Puppet::Error,
+        expect { catalogue }.to raise_error(Puppet::Error,
           /The auth_method you specified \[peer\] must be one of: trust, reject, md5, sha1, password, gss, sspi, krb5, ident, ldap, radius, cert, pam/)
       end
     end

--- a/modules/postgresql/spec/unit/defines/server/pg_ident_rule_spec.rb
+++ b/modules/postgresql/spec/unit/defines/server/pg_ident_rule_spec.rb
@@ -59,7 +59,7 @@ describe 'postgresql::server::pg_ident_rule', :type => :define do
       }
     end
     it 'should fail because $manage_pg_ident_conf is false' do
-      expect {subject}.to raise_error(Puppet::Error,
+      expect { catalogue }.to raise_error(Puppet::Error,
                                       /postgresql::server::manage_pg_ident_conf has been disabled/)
     end
   end


### PR DESCRIPTION
openssl is needed for katello-certs-check 