### PR TITLE
Refs #10210: Explicitly set CRL to false since empty value is not the same.

### DIFF
--- a/config/answers.katello-installer.yaml
+++ b/config/answers.katello-installer.yaml
@@ -17,7 +17,7 @@ foreman:
   server_ssl_key: /etc/pki/katello/private/katello-apache.key
   server_ssl_ca: /etc/pki/katello/certs/katello-default-ca.crt
   server_ssl_chain: /etc/pki/katello/certs/katello-default-ca.crt
-  server_ssl_crl:
+  server_ssl_crl: false
   websockets_encrypt: true
   websockets_ssl_key: /etc/pki/katello/private/katello-apache.key
   websockets_ssl_cert: /etc/pki/katello/certs/katello-apache.crt


### PR DESCRIPTION
I previously tried to use an empty value to mean empty string but that isn't the same so explicitly setting this value to false.