### PR TITLE
fixes #10221 - handle services and failures better during upgrades

### DIFF
--- a/hooks/boot/01-helpers.rb
+++ b/hooks/boot/01-helpers.rb
@@ -7,7 +7,8 @@ class Kafo::Helpers
     end
 
     def log_and_say(level, message)
-      say "<%= color('#{message}', :#{level.to_s}) %>"
+      style = level == :error ? 'bad' : level
+      say "<%= color('#{message}', :#{style}) %>"
       Kafo::KafoConfigure.logger.send(level, message)
     end
 

--- a/hooks/pre/30-upgrade.rb
+++ b/hooks/pre/30-upgrade.rb
@@ -1,3 +1,13 @@
+def stop_services
+  Kafo::Helpers.execute('katello-service stop --exclude mongod')
+end
+
+def start_mongo
+  status = Kafo::Helpers.execute('service-wait mongod status')
+  Kafo::Helpers.execute('service-wait mongod start') unless status
+  Kafo::Helpers.execute('service-wait mongod status')
+end
+
 def migrate_candlepin
   Kafo::Helpers.execute("/usr/share/candlepin/cpdb --update --password #{Kafo::Helpers.read_cache_data('candlepin_db_password')}")
 end
@@ -27,14 +37,24 @@ end
 def upgrade_step(step)
   noop = app_value(:noop) ? ' (noop)' : ''
 
-  Kafo::Helpers.log_and_say :info, "Upgrade Step: #{step.to_s}#{noop}..."
-  send(step) unless app_value(:noop)
+  Kafo::Helpers.log_and_say :info, "Upgrade Step: #{step}#{noop}..."
+  unless app_value(:noop)
+    status = send(step)
+    fail_and_exit "Upgrade step #{step} failed. Check logs for more information." unless status
+  end
+end
+
+def fail_and_exit(message)
+  Kafo::Helpers.log_and_say :error, message
+  kafo.class.exit 1
 end
 
 if app_value(:upgrade)
   Kafo::Helpers.log_and_say :info, 'Upgrading...'
+  upgrade_step :stop_services
 
   if Kafo::Helpers.module_enabled?(@kafo, 'katello') || @kafo.param('capsule', 'pulp').value
+    upgrade_step :start_mongo
     upgrade_step :migrate_pulp
   end
 


### PR DESCRIPTION
We only need mongo started; having candlepin running generates some errors in the logs (temporary).  Also, we should just abort if one of the upgrade steps fails instead of silently continuing.
