### PR TITLE
fixes #9680 - ensure httpd is started for access to repos

### DIFF
--- a/hooks/pre/30-upgrade.rb
+++ b/hooks/pre/30-upgrade.rb
@@ -1,11 +1,17 @@
 def stop_services
-  Kafo::Helpers.execute('katello-service stop --exclude mongod')
+  Kafo::Helpers.execute('katello-service stop --exclude mongod,httpd')
 end
 
 def start_mongo
   status = Kafo::Helpers.execute('service-wait mongod status')
   Kafo::Helpers.execute('service-wait mongod start') unless status
   Kafo::Helpers.execute('service-wait mongod status')
+end
+
+def start_httpd
+  status = Kafo::Helpers.execute('service-wait httpd status')
+  Kafo::Helpers.execute('service-wait httpd start') unless status
+  Kafo::Helpers.execute('service-wait httpd status')
 end
 
 def migrate_candlepin
@@ -59,6 +65,7 @@ if app_value(:upgrade)
 
   if Kafo::Helpers.module_enabled?(@kafo, 'katello') || @kafo.param('capsule', 'pulp').value
     upgrade_step :start_mongo
+    upgrade_step :start_httpd
     upgrade_step :migrate_pulp
   end
 


### PR DESCRIPTION
When user enables new features that weren't previously enbaled, the installer needs access to the repos hosted on the Katello itself.  Having httpd running during the upgrade allows this to happen.