### PR TITLE
fixes #10716 - migrate pulp in post as well

### DIFF
--- a/hooks/post/30-upgrade.rb
+++ b/hooks/post/30-upgrade.rb
@@ -1,9 +1,14 @@
 if app_value(:upgrade)
-  if Kafo::Helpers.module_enabled?(@kafo, 'katello')
-    noop = app_value(:noop) ? ' (noop)' : ''
+  if Kafo::Helpers.module_enabled?(@kafo, 'katello') || @kafo.param('capsule', 'pulp').value
+    Kafo::Helpers.log_and_say :info, "Upgrade Step: migrate_pulp...#{noop}"
+    Kafo::Helpers.execute('su - apache -s /bin/bash -c pulp-manage-db') unless app_value(:noop)
 
     Kafo::Helpers.log_and_say :info, "Upgrade Step: Restarting services...#{noop}"
     Kafo::Helpers.execute('katello-service restart') unless app_value(:noop)
+  end
+
+  if Kafo::Helpers.module_enabled?(@kafo, 'katello')
+    noop = app_value(:noop) ? ' (noop)' : ''
 
     Kafo::Helpers.log_and_say :info, "Upgrade Step: db:seed...#{noop}"
     Kafo::Helpers.execute('foreman-rake db:seed') unless app_value(:noop)


### PR DESCRIPTION
Pulp database is migrated before pulp-plugins-docker is installed during an uprade, which results in errors like this:

```
Importer docker_importer: no type definition found for docker_image
Jun 05 08:59:09 capsule.stbenjam.satellite.lab.eng.rdu2.redhat.com pulp15120: pulp.server.webservices.application:CRITICAL: *****************************************************
```

The pulp database should be migrated in post, as well, in case we installed any additional pulp plugins.
