### PR TITLE
Fixes #11041: Setup GPG fragment properly for Apache 1.1.X module.

### DIFF
--- a/modules/pulp/manifests/child/config.pp
+++ b/modules/pulp/manifests/child/config.pp
@@ -20,6 +20,16 @@ class pulp::child::config {
     ssl_verify_client => 'optional',
     ssl_options       => '+StdEnvVars',
     ssl_verify_depth  => '3',
+    custom_fragment   => template('pulp/etc/httpd/conf.d/_pulp_node_ssl_include.erb'),
+  }
+
+  file { "${apache::confd_dir}/25-pulp-node-ssl.d":
+    ensure  => 'directory',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0755',
+    purge   => true,
+    recurse => true,
   }
 
   # we need to make sure the goferd reads the current oauth credentials to talk

--- a/modules/pulp/manifests/child/fragment.pp
+++ b/modules/pulp/manifests/child/fragment.pp
@@ -4,15 +4,28 @@
 #  === Parameters:
 #
 #  $ssl_content:: content of the ssl virtual host fragment
+#
 define pulp::child::fragment(
-  $ssl_content = undef,
-  $order       = 15,
+  $ssl_content=undef,
 ) {
 
-  concat::fragment { $name:
-    target  => '25-pulp-node-ssl.conf',
-    content => $ssl_content,
-    order   => $order,
+  require pulp::child::config
+
+  $https_path = "${apache::confd_dir}/25-pulp-node-ssl.d/${name}.conf"
+
+  if $ssl_content and $ssl_content != '' and $ssl_content != undef {
+    file { $https_path:
+      ensure  => file,
+      content => $ssl_content,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+    }
+  } else {
+    file { $https_path:
+      ensure => absent,
+    }
   }
 
+  File[$https_path] ~> Class['apache::service']
 }

--- a/modules/pulp/templates/etc/httpd/conf.d/_pulp_node_ssl_include.erb
+++ b/modules/pulp/templates/etc/httpd/conf.d/_pulp_node_ssl_include.erb
@@ -1,0 +1,6 @@
+<IfVersion < 2.4>
+  Include <%= File.join(scope.lookupvar('apache::confd_dir'), '/25-pulp-node-ssl.d/*.conf') %>
+</IfVersion>
+<IfVersion >= 2.4>
+  IncludeOptional <%= File.join(scope.lookupvar('apache::confd_dir'), '/25-pulp-node-ssl.d/*.conf') %>
+</IfVersion>


### PR DESCRIPTION
The Apache 1.1.X module does not contain the ability to concat fragments
directly onto the apache vhost which is what this version of the installer
contains.