### PR TITLE
refs #10675 - templates off by default for upgrade, too

### DIFF
--- a/migrate/answers.katello-installer.yaml/02-templates_off.yaml
+++ b/migrate/answers.katello-installer.yaml/02-templates_off.yaml
@@ -1,0 +1,4 @@
+---
+add:
+  capsule:
+    templates: false


### PR DESCRIPTION
I'm like 0 for 2 today.  https://github.com/Katello/katello-installer/pull/243 was not a complete fix. Templates would still get enabled on an upgrade, we need a migration to add it to existing answers.

