### PR TITLE
Fixes #11334: Change to gzip to mimic Github's compression

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,7 @@ namespace :pkg do
 
     `git archive --prefix=katello-installer-#{version}/ HEAD > #{PKGDIR}/katello-installer-#{version}.tar`
     `tar --concatenate --file=#{PKGDIR}/katello-installer-#{version}.tar #{BUILDDIR}/modules.tar`
-    `bzip2 -9 #{PKGDIR}/katello-installer-#{version}.tar`
+    `gzip -9 #{PKGDIR}/katello-installer-#{version}.tar`
   end
 end
 


### PR DESCRIPTION
This also moves the compression format over to gzip to follow the
style that github uses since that is where we grab/store our archives.