### PR TITLE
Fixes #11856 - Updating katello-certs-check #265

### DIFF
--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -87,10 +87,18 @@ check-ca-bundle
 
 if [ $EXIT_CODE == "0" ]; then
     cat <<EOF
+
 Validation succeeded.
 
-To use the certificates on the Katello main server, run:
+To install the Katello main server with the custom certificates, run:
 
+    katello-installer --certs-server-cert "$CERT_FILE"\\
+                      --certs-server-cert-req "$REQ_FILE"\\
+                      --certs-server-key "$KEY_FILE"\\
+                      --certs-server-ca-cert "$CA_BUNDLE_FILE"
+
+To update the certificates on a currently running Katello installation, run:
+    
     katello-installer --certs-server-cert "$CERT_FILE"\\
                       --certs-server-cert-req "$REQ_FILE"\\
                       --certs-server-key "$KEY_FILE"\\


### PR DESCRIPTION
updated script to take into account new installs, as the --update-certs flag is not needed for a 1st time run