### PR TITLE
fixes #12000 - support remote execution in installer

### DIFF
--- a/config/answers.katello-installer.yaml
+++ b/config/answers.katello-installer.yaml
@@ -37,6 +37,7 @@ foreman::plugin::default_hostgroup: false
 foreman::plugin::puppetdb: false
 foreman::plugin::setup: false
 foreman::plugin::templates: false
+foreman::plugin::remote_execution: false
 
 katello::plugin::gutterball: true
 

--- a/config/katello-installer.yaml
+++ b/config/katello-installer.yaml
@@ -45,6 +45,10 @@
     :foreman::plugin::templates:
       :dir_name: foreman
       :manifest_name: plugin/templates
+    :foreman::plugin::remote_execution:
+      :dir_name: foreman
+      :manifest_name: plugin/remote_execution
+      :params_name: plugin/remote_execution/params
     :foreman::plugin::setup:
       :dir_name: foreman
       :manifest_name: plugin/setup

--- a/migrate/answers.katello-installer.yaml/04-remote_execution.yaml
+++ b/migrate/answers.katello-installer.yaml/04-remote_execution.yaml
@@ -1,0 +1,3 @@
+---
+add:
+  foreman::plugin::remote_execution: false

--- a/migrate/katello-installer.yaml/02-remote_execution.yaml
+++ b/migrate/katello-installer.yaml/02-remote_execution.yaml
@@ -1,0 +1,6 @@
+---
+add:
+  :mapping:
+    :foreman::plugin::remote_execution:
+      :dir_name: foreman
+      :manifest_name: plugin/remote_execution


### PR DESCRIPTION
Still a WIP, need to figure out how to handle the foreman proxy plugins, as foreman proxy isn't at the top level.