### PR TITLE
fixes #12550 - adding initial config and answers for capsule scenario.

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -26,7 +26,6 @@ mod 'katello-capsule',          :git => 'https://github.com/Katello/puppet-capsu
 mod 'katello-certs',            :git => 'https://github.com/Katello/puppet-certs'
 mod 'katello-common',           :git => 'https://github.com/Katello/puppet-common'
 mod 'katello-crane',            :git => 'https://github.com/Katello/puppet-crane'
-mod 'katello-elasticsearch',    :git => 'https://github.com/Katello/puppet-elasticsearch'
 mod 'katello-gutterball',       :git => 'https://github.com/Katello/puppet-gutterball'
 mod 'katello-katello',          :git => 'https://github.com/Katello/puppet-katello'
 mod 'katello-pulp',             :git => 'https://github.com/Katello/puppet-pulp'

--- a/checks/lang.rb
+++ b/checks/lang.rb
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+
+INVALID_LANG = %q(The LANG envrionment variable should not be set to C)
+
+def error_exit(message, code)
+  $stderr.puts message
+  exit code
+end
+
+error_exit(INVALID_LANG, 1)  if ENV["LANG"] == "C"

--- a/config/answers.capsule-installer.yaml
+++ b/config/answers.capsule-installer.yaml
@@ -3,3 +3,18 @@ certs:
   generate: false
   deploy: true
 capsule: true
+foreman_proxy:
+  custom_repo: true
+  http: true
+  ssl_port: '9090'
+  templates: true
+  tftp: false
+  ssl_ca: /etc/foreman-proxy/ssl_ca.pem
+  ssl_cert: /etc/foreman-proxy/ssl_cert.pem
+  ssl_key: /etc/foreman-proxy/ssl_key.pem
+  foreman_ssl_ca: /etc/foreman-proxy/foreman_ssl_ca.pem
+  foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
+  foreman_ssl_key: /etc/foreman-proxy/foreman_ssl_key.pem
+foreman_proxy::plugin::pulp:
+  enabled: false
+  pulpnode_enabled: true

--- a/config/answers.katello-devel-installer.yaml
+++ b/config/answers.katello-devel-installer.yaml
@@ -10,9 +10,20 @@ katello_devel:
   rvm: true
 capsule:
   puppet: true
-  puppetca: true
   pulp_master: true
-  register_in_foreman: true
-
+foreman_proxy:
+  custom_repo: true
+  http: true
+  port: '9090'
+  ssl_port: '9090'
+  templates: true
+  tftp: false
+  ssl_ca: /etc/foreman-proxy/ssl_ca.pem
+  ssl_cert: /etc/foreman-proxy/ssl_cert.pem
+  ssl_key: /etc/foreman-proxy/ssl_key.pem
+  foreman_ssl_ca: /etc/foreman-proxy/foreman_ssl_ca.pem
+  foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
+  foreman_ssl_key: /etc/foreman-proxy/foreman_ssl_key.pem
+foreman_proxy::plugin::pulp: true
 katello_devel::plugin::gutterball: true
 katello_devel::plugin::foreman_gutterball: true

--- a/config/answers.katello-installer.yaml
+++ b/config/answers.katello-installer.yaml
@@ -28,9 +28,9 @@ capsule:
   puppetca: true
   templates: false
 
-foreman::plugin::bootdisk: true
-foreman::plugin::discovery: true
-foreman::plugin::hooks: true
+foreman::plugin::bootdisk: false
+foreman::plugin::discovery: false
+foreman::plugin::hooks: false
 foreman::plugin::tasks: true
 foreman::plugin::chef: false
 foreman::plugin::default_hostgroup: false

--- a/config/answers.katello-installer.yaml
+++ b/config/answers.katello-installer.yaml
@@ -22,11 +22,22 @@ foreman:
   websockets_ssl_key: /etc/pki/katello/private/katello-apache.key
   websockets_ssl_cert: /etc/pki/katello/certs/katello-apache.crt
 capsule:
-  register_in_foreman: true
   pulp_master: true
   puppet: true
-  puppetca: true
-  templates: false
+foreman_proxy:
+  custom_repo: true
+  http: true
+  port: '9090'
+  ssl_port: '9090'
+  templates: true
+  tftp: false
+  ssl_ca: /etc/foreman-proxy/ssl_ca.pem
+  ssl_cert: /etc/foreman-proxy/ssl_cert.pem
+  ssl_key: /etc/foreman-proxy/ssl_key.pem
+  foreman_ssl_ca: /etc/foreman-proxy/foreman_ssl_ca.pem
+  foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
+  foreman_ssl_key: /etc/foreman-proxy/foreman_ssl_key.pem
+foreman_proxy::plugin::pulp: true
 
 foreman::plugin::bootdisk: false
 foreman::plugin::discovery: false

--- a/config/answers.katello-installer.yaml
+++ b/config/answers.katello-installer.yaml
@@ -37,6 +37,7 @@ foreman::plugin::default_hostgroup: false
 foreman::plugin::puppetdb: false
 foreman::plugin::setup: false
 foreman::plugin::templates: false
+foreman::plugin::remote_execution: false
 
 katello::plugin::gutterball: true
 

--- a/config/capsule-answers.yaml
+++ b/config/capsule-answers.yaml
@@ -1,0 +1,65 @@
+# Format:
+# <classname>: false - don't include this class
+# <classname>: true - include and use the defaults
+# <classname>:
+#   <param>: <value> - include and override the default(s)
+#
+# Every support plugin/compute class is listed, so that it
+# shows up in the interactive menu
+#
+# See params.pp in each class for what options are available
+---
+foreman_proxy:
+  custom_repo: true
+  puppetca: true
+  http: true
+  http_port: '8000'
+  ssl_port: '9090'
+  register_in_foreman: true
+  templates: true
+  tftp: false
+  ssl_ca: /etc/foreman-proxy/ssl_ca.pem
+  ssl_cert: /etc/foreman-proxy/ssl_cert.pem
+  ssl_key: /etc/foreman-proxy/ssl_key.pem
+  foreman_ssl_ca: /etc/foreman-proxy/foreman_ssl_ca.pem
+  foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
+  foreman_ssl_key: /etc/foreman-proxy/foreman_ssl_key.pem
+puppet: false
+certs:
+  generate: false
+  deploy: true
+capsule:
+  puppet: true
+foreman::plugin::bootdisk: false
+foreman::plugin::chef: false
+foreman::plugin::default_hostgroup: false
+foreman::plugin::dhcp_browser: false
+foreman::plugin::digitalocean: false
+foreman::plugin::discovery: false
+foreman::plugin::docker: false
+foreman::plugin::openscap: false
+foreman::plugin::ovirt_provision: false
+foreman::plugin::tasks: false
+foreman::plugin::hooks: false
+foreman::plugin::puppetdb: false
+foreman::plugin::remote_execution: false
+foreman::plugin::salt: false
+foreman::plugin::setup: true
+foreman::plugin::templates: false
+foreman::compute::ec2: false
+foreman::compute::gce: false
+foreman::compute::libvirt: false
+foreman::compute::openstack: false
+foreman::compute::ovirt: false
+foreman::compute::rackspace: false
+foreman::compute::vmware: false
+foreman_proxy::plugin::abrt: false
+foreman_proxy::plugin::chef: false
+foreman_proxy::plugin::dns::powerdns: false
+foreman_proxy::plugin::dynflow: false
+foreman_proxy::plugin::openscap: false
+foreman_proxy::plugin::pulp:
+  enabled: false
+  pulpnode_enabled: true
+foreman_proxy::plugin::remote_execution::ssh: false
+foreman_proxy::plugin::salt: false

--- a/config/capsule-installer.yaml
+++ b/config/capsule-installer.yaml
@@ -1,7 +1,8 @@
 ---
   :log_dir: /var/log/capsule-installer
   :log_name: capsule-installer.log
-  :log_level: :debug
+  :log_level: DEBUG
+
   :no_prefix: true
   :answer_file: "./config/answers.capsule-installer.yaml"
   :installer_dir: "."
@@ -12,3 +13,37 @@
   :order:
     - certs
     - capsule
+    - foreman_proxy
+  :mapping:
+    :foreman_proxy::plugin::abrt:
+      :manifest_name: plugin/abrt
+      :params_name: plugin/abrt/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::chef:
+      :manifest_name: plugin/chef
+      :params_name: plugin/chef/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::dns::powerdns:
+      :manifest_name: plugin/dns/powerdns
+      :params_name: plugin/dns/powerdns/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::dynflow:
+      :manifest_name: plugin/dynflow
+      :params_name: plugin/dynflow/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::openscap:
+      :manifest_name: plugin/openscap
+      :params_name: plugin/openscap/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::pulp:
+      :manifest_name: plugin/pulp
+      :params_name: plugin/pulp/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::remote_execution::ssh:
+      :manifest_name: plugin/remote_execution/ssh
+      :params_name: plugin/remote_execution/ssh/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::salt:
+      :manifest_name: plugin/salt
+      :params_name: plugin/salt/params
+      :dir_name: foreman_proxy

--- a/config/capsule.yaml
+++ b/config/capsule.yaml
@@ -1,0 +1,150 @@
+## Installer configuration
+:answer_file: /etc/foreman/installer-scenarios.d/capsule-answers.yaml
+:installer_dir: /usr/share/foreman-installer
+:check_dirs: ["/usr/share/foreman-installer/checks", "/usr/share/katello-installer/checks"]
+:module_dirs: ["/usr/share/foreman-installer/modules", "/usr/share/katello-installer/modules"]
+
+## Useful for development, e.g. when you want to move log files to local directory
+:log_dir: '/var/log/foreman-installer'
+:log_name: 'foreman-installer.log'
+:log_level: :debug
+
+# Change if you want to debug default answers for you modules, this directory holds default answers
+# :default_values_dir: /tmp
+
+## Advanced configuration - if not set it's ignored
+# :log_owner: root
+# :log_group: root
+# :config_header_file:
+# :dont_save_answers:
+
+# If using the Debian ruby-kafo package, uncomment this
+# :kafo_modules_dir: /usr/share/foreman-installer/modules
+
+## Kafo tuning, customization of core functionality
+:name: Capsule
+:description: Install a stand-alone Capsule.
+# :no_prefix: false
+:order:
+  - certs
+  - foreman
+  - capsule
+  - foreman_proxy
+  - puppet
+:low_priority_modules:
+  - foreman_proxy_plugin
+  - foreman_compute
+  - foreman_plugin
+
+# The mapping hash provides Kafo with the information to find plugin classes
+:mapping:
+  :foreman::cli:
+    :dir_name: foreman
+    :manifest_name: cli
+    :params_name: cli/params
+  :foreman::plugin::bootdisk:
+    :dir_name: foreman
+    :manifest_name: plugin/bootdisk
+  :foreman::plugin::puppetdb:
+    :dir_name: foreman
+    :params_name: plugin/puppetdb/params
+    :manifest_name: plugin/puppetdb
+  :foreman::plugin::hooks:
+    :dir_name: foreman
+    :manifest_name: plugin/hooks
+  :foreman::plugin::dhcp_browser:
+    :dir_name: foreman
+    :manifest_name: plugin/dhcp_browser
+  :foreman::plugin::digitalocean:
+    :dir_name: foreman
+    :manifest_name: plugin/digitalocean
+  :foreman::plugin::discovery:
+    :dir_name: foreman
+    :manifest_name: plugin/discovery
+    :params_name: plugin/discovery/params
+  :foreman::plugin::docker:
+    :dir_name: foreman
+    :manifest_name: plugin/docker
+  :foreman::plugin::openscap:
+    :dir_name: foreman
+    :params_name: plugin/openscap/params
+    :manifest_name: plugin/openscap
+  :foreman::plugin::ovirt_provision:
+    :dir_name: foreman
+    :params_name: plugin/ovirt_provision/params
+    :manifest_name: plugin/ovirt_provision
+  :foreman::plugin::chef:
+    :dir_name: foreman
+    :manifest_name: plugin/chef
+  :foreman::plugin::tasks:
+    :dir_name: foreman
+    :params_name: plugin/tasks/params
+    :manifest_name: plugin/tasks
+  :foreman::plugin::templates:
+    :dir_name: foreman
+    :manifest_name: plugin/templates
+  :foreman::plugin::remote_execution:
+    :dir_name: foreman
+    :manifest_name: plugin/remote_execution
+  :foreman::plugin::salt:
+    :dir_name: foreman
+    :manifest_name: plugin/salt
+  :foreman::plugin::setup:
+    :dir_name: foreman
+    :manifest_name: plugin/setup
+  :foreman::plugin::default_hostgroup:
+    :dir_name: foreman
+    :manifest_name: plugin/default_hostgroup
+  :foreman::compute::rackspace:
+    :dir_name: foreman
+    :manifest_name: compute/rackspace
+  :foreman::compute::openstack:
+    :dir_name: foreman
+    :manifest_name: compute/openstack
+  :foreman::compute::vmware:
+    :dir_name: foreman
+    :manifest_name: compute/vmware
+  :foreman::compute::libvirt:
+    :dir_name: foreman
+    :manifest_name: compute/libvirt
+  :foreman::compute::ec2:
+    :dir_name: foreman
+    :manifest_name: compute/ec2
+  :foreman::compute::gce:
+    :dir_name: foreman
+    :manifest_name: compute/gce
+  :foreman::compute::ovirt:
+    :dir_name: foreman
+    :manifest_name: compute/ovirt
+  :foreman_proxy::plugin::abrt:
+    :manifest_name: plugin/abrt
+    :params_name: plugin/abrt/params
+    :dir_name: foreman_proxy
+  :foreman_proxy::plugin::chef:
+    :manifest_name: plugin/chef
+    :params_name: plugin/chef/params
+    :dir_name: foreman_proxy
+  :foreman_proxy::plugin::dns::powerdns:
+    :manifest_name: plugin/dns/powerdns
+    :params_name: plugin/dns/powerdns/params
+    :dir_name: foreman_proxy
+  :foreman_proxy::plugin::dynflow:
+    :manifest_name: plugin/dynflow
+    :params_name: plugin/dynflow/params
+    :dir_name: foreman_proxy
+  :foreman_proxy::plugin::openscap:
+    :manifest_name: plugin/openscap
+    :params_name: plugin/openscap/params
+    :dir_name: foreman_proxy
+  :foreman_proxy::plugin::pulp:
+    :manifest_name: plugin/pulp
+    :params_name: plugin/pulp/params
+    :dir_name: foreman_proxy
+  :foreman_proxy::plugin::remote_execution::ssh:
+    :manifest_name: plugin/remote_execution/ssh
+    :params_name: plugin/remote_execution/ssh/params
+    :dir_name: foreman_proxy
+  :foreman_proxy::plugin::salt:
+    :manifest_name: plugin/salt
+    :params_name: plugin/salt/params
+    :dir_name: foreman_proxy

--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -1,0 +1,79 @@
+---
+certs:
+  generate: true
+  deploy: true
+  group: foreman
+katello: true
+foreman:
+  organizations_enabled: true
+  locations_enabled: true
+  initial_organization: Default Organization
+  initial_location: Default Location
+  custom_repo: true
+  configure_epel_repo: false
+  configure_scl_repo: false
+  ssl: true
+  server_ssl_cert: /etc/pki/katello/certs/katello-apache.crt
+  server_ssl_key: /etc/pki/katello/private/katello-apache.key
+  server_ssl_ca: /etc/pki/katello/certs/katello-default-ca.crt
+  server_ssl_chain: /etc/pki/katello/certs/katello-default-ca.crt
+  server_ssl_crl: false
+  websockets_encrypt: true
+  websockets_ssl_key: /etc/pki/katello/private/katello-apache.key
+  websockets_ssl_cert: /etc/pki/katello/certs/katello-apache.crt
+foreman_proxy:
+  custom_repo: true
+  puppetca: true
+  http: true
+  http_port: '8000'
+  ssl_port: '9090'
+  register_in_foreman: true
+  templates: false
+  tftp: false
+  ssl_ca: /etc/foreman-proxy/ssl_ca.pem
+  ssl_cert: /etc/foreman-proxy/ssl_cert.pem
+  ssl_key: /etc/foreman-proxy/ssl_key.pem
+  foreman_ssl_ca: /etc/foreman-proxy/foreman_ssl_ca.pem
+  foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
+  foreman_ssl_key: /etc/foreman-proxy/foreman_ssl_key.pem
+capsule:
+  pulp_master: true
+  puppet: true
+
+katello::plugin::gutterball: true
+
+foreman::cli: true
+foreman::plugin::bootdisk: false
+foreman::plugin::chef: false
+foreman::plugin::cockpit: false
+foreman::plugin::default_hostgroup: false
+foreman::plugin::dhcp_browser: false
+foreman::plugin::digitalocean: false
+foreman::plugin::discovery: false
+foreman::plugin::docker: false
+foreman::plugin::memcache: false
+foreman::plugin::openscap: false
+foreman::plugin::ovirt_provision: false
+foreman::plugin::tasks: true
+foreman::plugin::hooks: false
+foreman::plugin::puppetdb: false
+foreman::plugin::remote_execution: false
+foreman::plugin::salt: false
+foreman::plugin::setup: false
+foreman::plugin::templates: false
+foreman::compute::ec2: false
+foreman::compute::gce: false
+foreman::compute::libvirt: false
+foreman::compute::openstack: false
+foreman::compute::ovirt: false
+foreman::compute::rackspace: false
+foreman::compute::vmware: false
+foreman_proxy::plugin::abrt: false
+foreman_proxy::plugin::chef: false
+foreman_proxy::plugin::discovery: false
+foreman_proxy::plugin::dns::powerdns: false
+foreman_proxy::plugin::dynflow: false
+foreman_proxy::plugin::openscap: false
+foreman_proxy::plugin::pulp: false
+foreman_proxy::plugin::remote_execution::ssh: false
+foreman_proxy::plugin::salt: false

--- a/config/katello-devel-installer.yaml
+++ b/config/katello-devel-installer.yaml
@@ -1,7 +1,7 @@
 ---
   :log_dir: /var/log/katello-devel-installer
   :log_name: katello-devel-installer.log
-  :log_level: :debug
+  :log_level: DEBUG
   :no_prefix: true
   :answer_file: "./config/answers.katello-devel-installer.yaml"
   :installer_dir: "."
@@ -11,6 +11,7 @@
   :order:
     - certs
     - katello_devel
+    - foreman_proxy
   :password: l7VtnWiPeKe412o2CVBM6yVbTkKGh6L_CKx4_zBkmUE
 
   :mapping:
@@ -20,3 +21,7 @@
     :katello_devel::plugin::foreman_gutterball:
       :dir_name: katello_devel
       :manifest_name: plugin/foreman_gutterball
+    :foreman_proxy::plugin::pulp:
+      :manifest_name: plugin/pulp
+      :params_name: plugin/pulp/params
+      :dir_name: foreman_proxy

--- a/config/katello-installer.yaml
+++ b/config/katello-installer.yaml
@@ -45,6 +45,10 @@
     :foreman::plugin::templates:
       :dir_name: foreman
       :manifest_name: plugin/templates
+    :foreman::plugin::remote_execution:
+      :dir_name: foreman
+      :manifest_name: plugin/remote_execution
+      :params_name: plugin/remote_execution/params
     :foreman::plugin::setup:
       :dir_name: foreman
       :manifest_name: plugin/setup

--- a/config/katello-installer.yaml
+++ b/config/katello-installer.yaml
@@ -1,7 +1,7 @@
 ---
   :log_dir: /var/log/katello-installer
   :log_name: katello-installer.log
-  :log_level: :debug
+  :log_level: DEBUG
   :no_prefix: false
   :answer_file: "./config/answers.katello-installer.yaml"
   :installer_dir: "."
@@ -15,6 +15,7 @@
     - foreman
     - katello
     - capsule
+    - foreman_proxy
 
   # The mapping hash provides Kafo with the information to find plugin classes
   :mapping:
@@ -76,3 +77,35 @@
     :foreman::compute::ovirt:
       :dir_name: foreman
       :manifest_name: compute/ovirt
+    :foreman_proxy::plugin::abrt:
+      :manifest_name: plugin/abrt
+      :params_name: plugin/abrt/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::chef:
+      :manifest_name: plugin/chef
+      :params_name: plugin/chef/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::dns::powerdns:
+      :manifest_name: plugin/dns/powerdns
+      :params_name: plugin/dns/powerdns/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::dynflow:
+      :manifest_name: plugin/dynflow
+      :params_name: plugin/dynflow/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::openscap:
+      :manifest_name: plugin/openscap
+      :params_name: plugin/openscap/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::pulp:
+      :manifest_name: plugin/pulp
+      :params_name: plugin/pulp/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::remote_execution::ssh:
+      :manifest_name: plugin/remote_execution/ssh
+      :params_name: plugin/remote_execution/ssh/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::salt:
+      :manifest_name: plugin/salt
+      :params_name: plugin/salt/params
+      :dir_name: foreman_proxy

--- a/config/katello.yaml
+++ b/config/katello.yaml
@@ -1,0 +1,166 @@
+## Installer configuration
+:answer_file: /etc/foreman/installer-scenarios.d/katello-answers.yaml
+:installer_dir: /usr/share/foreman-installer
+:check_dirs: ["/usr/share/foreman-installer/checks", "/usr/share/katello-installer/checks"]
+:hook_dirs: ["/usr/share/foreman-installer/hooks", "/usr/share/katello-installer/hooks"]
+:module_dirs: ["/usr/share/foreman-installer/modules", "/usr/share/katello-installer/modules"]
+
+## Useful for development, e.g. when you want to move log files to local directory
+:log_dir: '/var/log/foreman-installer'
+:log_name: 'foreman-installer.log'
+:log_level: :debug
+
+# Change if you want to debug default answers for you modules, this directory holds default answers
+# :default_values_dir: /tmp
+
+## Advanced configuration - if not set it's ignored
+# :log_owner: root
+# :log_group: root
+# :config_header_file:
+# :dont_save_answers:
+
+# If using the Debian ruby-kafo package, uncomment this
+# :kafo_modules_dir: /usr/share/foreman-installer/modules
+
+## Kafo tuning, customization of core functionality
+:name: Katello
+:description: Install a stand-alone Katello.
+# :no_prefix: false
+:order:
+  - certs
+  - foreman
+  - katello
+  - capsule
+  - foreman_proxy
+  - puppet
+:low_priority_modules:
+  - foreman_proxy_plugin
+  - foreman_compute
+  - foreman_plugin
+
+# The mapping hash provides Kafo with the information to find plugin classes
+:mapping:
+  :katello::plugin::gutterball:
+    :dir_name: katello
+    :manifest_name: plugin/gutterball
+  :foreman::cli:
+    :dir_name: foreman
+    :manifest_name: cli
+    :params_name: cli/params
+  :foreman::plugin::bootdisk:
+    :dir_name: foreman
+    :manifest_name: plugin/bootdisk
+  :foreman::plugin::cockpit:
+    :dir_name: foreman
+    :manifest_name: plugin/cockpit
+  :foreman::plugin::puppetdb:
+    :dir_name: foreman
+    :params_name: plugin/puppetdb/params
+    :manifest_name: plugin/puppetdb
+  :foreman::plugin::hooks:
+    :dir_name: foreman
+    :manifest_name: plugin/hooks
+  :foreman::plugin::dhcp_browser:
+    :dir_name: foreman
+    :manifest_name: plugin/dhcp_browser
+  :foreman::plugin::digitalocean:
+    :dir_name: foreman
+    :manifest_name: plugin/digitalocean
+  :foreman::plugin::discovery:
+    :dir_name: foreman
+    :manifest_name: plugin/discovery
+    :params_name: plugin/discovery/params
+  :foreman::plugin::docker:
+    :dir_name: foreman
+    :manifest_name: plugin/docker
+  :foreman::plugin::memcache:
+    :dir_name: foreman
+    :manifest_name: plugin/memcache
+    :params_name: plugin/memcache/params
+  :foreman::plugin::openscap:
+    :dir_name: foreman
+    :params_name: plugin/openscap/params
+    :manifest_name: plugin/openscap
+  :foreman::plugin::ovirt_provision:
+    :dir_name: foreman
+    :params_name: plugin/ovirt_provision/params
+    :manifest_name: plugin/ovirt_provision
+  :foreman::plugin::chef:
+    :dir_name: foreman
+    :manifest_name: plugin/chef
+  :foreman::plugin::tasks:
+    :dir_name: foreman
+    :params_name: plugin/tasks/params
+    :manifest_name: plugin/tasks
+  :foreman::plugin::templates:
+    :dir_name: foreman
+    :manifest_name: plugin/templates
+  :foreman::plugin::remote_execution:
+    :dir_name: foreman
+    :manifest_name: plugin/remote_execution
+  :foreman::plugin::salt:
+    :dir_name: foreman
+    :manifest_name: plugin/salt
+  :foreman::plugin::setup:
+    :dir_name: foreman
+    :manifest_name: plugin/setup
+  :foreman::plugin::default_hostgroup:
+    :dir_name: foreman
+    :manifest_name: plugin/default_hostgroup
+  :foreman::compute::rackspace:
+    :dir_name: foreman
+    :manifest_name: compute/rackspace
+  :foreman::compute::openstack:
+    :dir_name: foreman
+    :manifest_name: compute/openstack
+  :foreman::compute::vmware:
+    :dir_name: foreman
+    :manifest_name: compute/vmware
+  :foreman::compute::libvirt:
+    :dir_name: foreman
+    :manifest_name: compute/libvirt
+  :foreman::compute::ec2:
+    :dir_name: foreman
+    :manifest_name: compute/ec2
+  :foreman::compute::gce:
+    :dir_name: foreman
+    :manifest_name: compute/gce
+  :foreman::compute::ovirt:
+    :dir_name: foreman
+    :manifest_name: compute/ovirt
+  :foreman_proxy::plugin::abrt:
+    :manifest_name: plugin/abrt
+    :params_name: plugin/abrt/params
+    :dir_name: foreman_proxy
+  :foreman_proxy::plugin::chef:
+    :manifest_name: plugin/chef
+    :params_name: plugin/chef/params
+    :dir_name: foreman_proxy
+  :foreman_proxy::plugin::discovery:
+    :manifest_name: plugin/discovery
+    :params_name: plugin/discovery/params
+    :dir_name: foreman_proxy
+  :foreman_proxy::plugin::dns::powerdns:
+    :manifest_name: plugin/dns/powerdns
+    :params_name: plugin/dns/powerdns/params
+    :dir_name: foreman_proxy
+  :foreman_proxy::plugin::dynflow:
+    :manifest_name: plugin/dynflow
+    :params_name: plugin/dynflow/params
+    :dir_name: foreman_proxy
+  :foreman_proxy::plugin::openscap:
+    :manifest_name: plugin/openscap
+    :params_name: plugin/openscap/params
+    :dir_name: foreman_proxy
+  :foreman_proxy::plugin::pulp:
+    :manifest_name: plugin/pulp
+    :params_name: plugin/pulp/params
+    :dir_name: foreman_proxy
+  :foreman_proxy::plugin::remote_execution::ssh:
+    :manifest_name: plugin/remote_execution/ssh
+    :params_name: plugin/remote_execution/ssh/params
+    :dir_name: foreman_proxy
+  :foreman_proxy::plugin::salt:
+    :manifest_name: plugin/salt
+    :params_name: plugin/salt/params
+    :dir_name: foreman_proxy

--- a/hooks/post/10-post_install.rb
+++ b/hooks/post/10-post_install.rb
@@ -1,10 +1,10 @@
 def proxy_available?
   Kafo::Helpers.module_enabled?(@kafo, 'capsule') &&
    (@kafo.param('capsule', 'puppet').value ||
-    @kafo.param('capsule', 'puppetca').value ||
-    @kafo.param('capsule', 'dhcp').value ||
-    @kafo.param('capsule', 'dns').value ||
-    @kafo.param('capsule', 'tftp').value)
+    @kafo.param('foreman_proxy', 'puppetca').value ||
+    @kafo.param('foreman_proxy', 'dhcp').value ||
+    @kafo.param('foreman_proxy', 'dns').value ||
+    @kafo.param('foreman_proxy', 'tftp').value)
 end
 
 if [0,2].include?(@kafo.exit_code)
@@ -21,7 +21,7 @@ if [0,2].include?(@kafo.exit_code)
 
     # Capsule?
     if proxy_available?
-      say "  * <%= color('Capsule', :info) %> is running at <%= color('https://#{fqdn}:#{@kafo.param('capsule', 'foreman_proxy_port').value}', :info) %>"
+      say "  * <%= color('Capsule', :info) %> is running at <%= color('https://#{fqdn}:#{@kafo.param('foreman_proxy', 'ssl_port').value}', :info) %>"
     end
 
     if Kafo::Helpers.module_enabled?(@kafo, 'katello')

--- a/hooks/pre/10-reset_feature.rb
+++ b/hooks/pre/10-reset_feature.rb
@@ -7,7 +7,6 @@ def reset
     reset_database
     reset_candlepin
     reset_pulp
-    reset_elasticsearch
 
   else
     Kafo::KafoConfigure.logger.warn 'Katello not installed yet, can not drop database!'
@@ -55,15 +54,6 @@ def reset_pulp
     'rm -rf /var/lib/pulp/{distributions,published,repos}/*'
   ]
 
-  Kafo::Helpers.execute(commands)
-end
-
-def reset_elasticsearch
-  Kafo::KafoConfigure.logger.info 'Dropping Elasticsearch!'
-  commands = [
-    'service-wait elasticsearch stop',
-    'rm -rf /var/lib/elasticsearch/*',
-  ]
   Kafo::Helpers.execute(commands)
 end
 

--- a/migrate/answers.katello-installer.yaml/04-remote_execution.yaml
+++ b/migrate/answers.katello-installer.yaml/04-remote_execution.yaml
@@ -1,0 +1,3 @@
+---
+add:
+  foreman::plugin::remote_execution: false

--- a/migrate/katello-installer.yaml/02-remote_execution.yaml
+++ b/migrate/katello-installer.yaml/02-remote_execution.yaml
@@ -1,0 +1,6 @@
+---
+add:
+  :mapping:
+    :foreman::plugin::remote_execution:
+      :dir_name: foreman
+      :manifest_name: plugin/remote_execution


### PR DESCRIPTION
This commit contains the initial answer and configuration file to support
the 'capsule' as a kafo installer scenario on top of the foreman-proxy.

The end goal is for this configuration to be used from the foreman-installer
to enable the user to install the capsule as a foreman-installer scenario
versus using the current separate capsule-installer.

Note: this is one of the changes being put in place to support the
'Katello on Foreman' feature.

Note: 
- This PR is currently for the 'katello-on-foreman' branch
- The naming convention chosen for the 2 files is based on what is currently used by foreman-installer config; therefore, they purposely look different from what capsule-installer uses today.
- Once accepted, we may want to remove files such as:
  - bin/capsule-installer
  - config/answers.capsule-installer.yaml
  - capsule-installer.yaml