### PR TITLE
fixes #10533 - update answers and config to decouple foreman_proxy from capsule

### DIFF
--- a/config/answers.capsule-installer.yaml
+++ b/config/answers.capsule-installer.yaml
@@ -3,3 +3,18 @@ certs:
   generate: false
   deploy: true
 capsule: true
+foreman_proxy:
+  custom_repo: true
+  http: true
+  ssl_port: '9090'
+  templates: true
+  tftp: false
+  ssl_ca: /etc/foreman-proxy/ssl_ca.pem
+  ssl_cert: /etc/foreman-proxy/ssl_cert.pem
+  ssl_key: /etc/foreman-proxy/ssl_key.pem
+  foreman_ssl_ca: /etc/foreman-proxy/foreman_ssl_ca.pem
+  foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
+  foreman_ssl_key: /etc/foreman-proxy/foreman_ssl_key.pem
+foreman_proxy::plugin::pulp:
+  enabled: false
+  pulpnode_enabled: true

--- a/config/answers.katello-devel-installer.yaml
+++ b/config/answers.katello-devel-installer.yaml
@@ -10,9 +10,20 @@ katello_devel:
   rvm: true
 capsule:
   puppet: true
-  puppetca: true
   pulp_master: true
-  register_in_foreman: true
-
+foreman_proxy:
+  custom_repo: true
+  http: true
+  port: '9090'
+  ssl_port: '9090'
+  templates: true
+  tftp: false
+  ssl_ca: /etc/foreman-proxy/ssl_ca.pem
+  ssl_cert: /etc/foreman-proxy/ssl_cert.pem
+  ssl_key: /etc/foreman-proxy/ssl_key.pem
+  foreman_ssl_ca: /etc/foreman-proxy/foreman_ssl_ca.pem
+  foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
+  foreman_ssl_key: /etc/foreman-proxy/foreman_ssl_key.pem
+foreman_proxy::plugin::pulp: true
 katello_devel::plugin::gutterball: true
 katello_devel::plugin::foreman_gutterball: true

--- a/config/answers.katello-installer.yaml
+++ b/config/answers.katello-installer.yaml
@@ -22,11 +22,22 @@ foreman:
   websockets_ssl_key: /etc/pki/katello/private/katello-apache.key
   websockets_ssl_cert: /etc/pki/katello/certs/katello-apache.crt
 capsule:
-  register_in_foreman: true
   pulp_master: true
   puppet: true
-  puppetca: true
-  templates: false
+foreman_proxy:
+  custom_repo: true
+  http: true
+  port: '9090'
+  ssl_port: '9090'
+  templates: true
+  tftp: false
+  ssl_ca: /etc/foreman-proxy/ssl_ca.pem
+  ssl_cert: /etc/foreman-proxy/ssl_cert.pem
+  ssl_key: /etc/foreman-proxy/ssl_key.pem
+  foreman_ssl_ca: /etc/foreman-proxy/foreman_ssl_ca.pem
+  foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
+  foreman_ssl_key: /etc/foreman-proxy/foreman_ssl_key.pem
+foreman_proxy::plugin::pulp: true
 
 foreman::plugin::bootdisk: true
 foreman::plugin::discovery: true

--- a/config/capsule-installer.yaml
+++ b/config/capsule-installer.yaml
@@ -1,7 +1,8 @@
 ---
   :log_dir: /var/log/capsule-installer
   :log_name: capsule-installer.log
-  :log_level: :debug
+  :log_level: DEBUG
+
   :no_prefix: true
   :answer_file: "./config/answers.capsule-installer.yaml"
   :installer_dir: "."
@@ -12,3 +13,37 @@
   :order:
     - certs
     - capsule
+    - foreman_proxy
+  :mapping:
+    :foreman_proxy::plugin::abrt:
+      :manifest_name: plugin/abrt
+      :params_name: plugin/abrt/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::chef:
+      :manifest_name: plugin/chef
+      :params_name: plugin/chef/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::dns::powerdns:
+      :manifest_name: plugin/dns/powerdns
+      :params_name: plugin/dns/powerdns/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::dynflow:
+      :manifest_name: plugin/dynflow
+      :params_name: plugin/dynflow/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::openscap:
+      :manifest_name: plugin/openscap
+      :params_name: plugin/openscap/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::pulp:
+      :manifest_name: plugin/pulp
+      :params_name: plugin/pulp/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::remote_execution::ssh:
+      :manifest_name: plugin/remote_execution/ssh
+      :params_name: plugin/remote_execution/ssh/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::salt:
+      :manifest_name: plugin/salt
+      :params_name: plugin/salt/params
+      :dir_name: foreman_proxy

--- a/config/katello-devel-installer.yaml
+++ b/config/katello-devel-installer.yaml
@@ -1,7 +1,7 @@
 ---
   :log_dir: /var/log/katello-devel-installer
   :log_name: katello-devel-installer.log
-  :log_level: :debug
+  :log_level: DEBUG
   :no_prefix: true
   :answer_file: "./config/answers.katello-devel-installer.yaml"
   :installer_dir: "."
@@ -11,6 +11,7 @@
   :order:
     - certs
     - katello_devel
+    - foreman_proxy
   :password: l7VtnWiPeKe412o2CVBM6yVbTkKGh6L_CKx4_zBkmUE
 
   :mapping:
@@ -20,3 +21,7 @@
     :katello_devel::plugin::foreman_gutterball:
       :dir_name: katello_devel
       :manifest_name: plugin/foreman_gutterball
+    :foreman_proxy::plugin::pulp:
+      :manifest_name: plugin/pulp
+      :params_name: plugin/pulp/params
+      :dir_name: foreman_proxy

--- a/config/katello-installer.yaml
+++ b/config/katello-installer.yaml
@@ -1,7 +1,7 @@
 ---
   :log_dir: /var/log/katello-installer
   :log_name: katello-installer.log
-  :log_level: :debug
+  :log_level: DEBUG
   :no_prefix: false
   :answer_file: "./config/answers.katello-installer.yaml"
   :installer_dir: "."
@@ -15,6 +15,7 @@
     - foreman
     - katello
     - capsule
+    - foreman_proxy
 
   # The mapping hash provides Kafo with the information to find plugin classes
   :mapping:
@@ -76,3 +77,35 @@
     :foreman::compute::ovirt:
       :dir_name: foreman
       :manifest_name: compute/ovirt
+    :foreman_proxy::plugin::abrt:
+      :manifest_name: plugin/abrt
+      :params_name: plugin/abrt/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::chef:
+      :manifest_name: plugin/chef
+      :params_name: plugin/chef/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::dns::powerdns:
+      :manifest_name: plugin/dns/powerdns
+      :params_name: plugin/dns/powerdns/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::dynflow:
+      :manifest_name: plugin/dynflow
+      :params_name: plugin/dynflow/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::openscap:
+      :manifest_name: plugin/openscap
+      :params_name: plugin/openscap/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::pulp:
+      :manifest_name: plugin/pulp
+      :params_name: plugin/pulp/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::remote_execution::ssh:
+      :manifest_name: plugin/remote_execution/ssh
+      :params_name: plugin/remote_execution/ssh/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::salt:
+      :manifest_name: plugin/salt
+      :params_name: plugin/salt/params
+      :dir_name: foreman_proxy

--- a/hooks/post/10-post_install.rb
+++ b/hooks/post/10-post_install.rb
@@ -1,10 +1,10 @@
 def proxy_available?
   Kafo::Helpers.module_enabled?(@kafo, 'capsule') &&
    (@kafo.param('capsule', 'puppet').value ||
-    @kafo.param('capsule', 'puppetca').value ||
-    @kafo.param('capsule', 'dhcp').value ||
-    @kafo.param('capsule', 'dns').value ||
-    @kafo.param('capsule', 'tftp').value)
+    @kafo.param('foreman_proxy', 'puppetca').value ||
+    @kafo.param('foreman_proxy', 'dhcp').value ||
+    @kafo.param('foreman_proxy', 'dns').value ||
+    @kafo.param('foreman_proxy', 'tftp').value)
 end
 
 if [0,2].include?(@kafo.exit_code)
@@ -21,7 +21,7 @@ if [0,2].include?(@kafo.exit_code)
 
     # Capsule?
     if proxy_available?
-      say "  * <%= color('Capsule', :info) %> is running at <%= color('https://#{fqdn}:#{@kafo.param('capsule', 'foreman_proxy_port').value}', :info) %>"
+      say "  * <%= color('Capsule', :info) %> is running at <%= color('https://#{fqdn}:#{@kafo.param('foreman_proxy', 'ssl_port').value}', :info) %>"
     end
 
     if Kafo::Helpers.module_enabled?(@kafo, 'katello')


### PR DESCRIPTION
This commit contains some initial changes to support the puppet-capsule
changes that decouple puppet-foreman_proxy from the puppet-capsule.
(Ref: https://github.com/Katello/puppet-capsule/pull/64)

The following is an example to install katello using this configuration:
```
katello-installer
```

The following is an example to install capsule using this configuration:
```
capsule-installer --register-in-foreman "true"\
                  --registered-proxy-url "https://capsule.example.com:9090"\
                  --oauth-consumer-key "pvUutwvPU3Rni5RWqisL6Tx4fAF5yDSa"\
                  --oauth-consumer-secret "JTGnd3fx6GB4uki5LtNPFU6cCSq9NrFk"\
                  --foreman-base-url "https://katello.example.com"\
                  --trusted-hosts "katello.example.com"\
                  --trusted-hosts "capsule.example.com"\
                  --parent-fqdn "katello.example.com"\
                  --pulp-oauth-secret "3HNmounKP6mbQYthkvkw2GXV5toxeFsu"\
                  --certs-tar "~/capsule.example.com-certs.tar"\
                  --puppet "true"\
                  --puppetca "true"\
                  --enable-foreman-proxy-plugin-pulp\
                  --enabled "false"\
                  --pulpnode-enabled "true"
```