### PR TITLE
Fixes #13687 - use the server cert for the certifiate_chain_file

### DIFF
--- a/config/katello.migrations/160802130342-certificate-chain-file.rb
+++ b/config/katello.migrations/160802130342-certificate-chain-file.rb
@@ -1,0 +1,3 @@
+if answers['foreman']['server_ssl_chain'] == '/etc/pki/katello/certs/katello-default-ca.crt'
+  answers['foreman']['server_ssl_chain'] = '/etc/pki/katello/certs/katello-server-ca.crt'
+end


### PR DESCRIPTION
the SSLCertificateChainFile is sent to the browser to verify the identity of
the server. The misconfiguration caused, that the user would need to have all
the certificates in the chain installed in the system. After this change, the
ROOT CA is enough to have on the system to verify the server cert.