### PR TITLE
Fixes #13924: Ensure proper ordering for devel dependencies

### DIFF
--- a/config/katello-devel.migrations/20160301144353-order.rb
+++ b/config/katello-devel.migrations/20160301144353-order.rb
@@ -1,0 +1,7 @@
+scenario[:order] = [
+  "certs",
+  "katello_devel",
+  "foreman_proxy",
+  "foreman_proxy::plugin::pulp",
+  "capsule"
+]


### PR DESCRIPTION
Crane configuration ended up with the wrong certs and key because
certs::apache in the capsule module was not resolving when the
module was evaluated.