### PR TITLE
Fixes #13198 - remove node importers and distributors from repos

### DIFF
--- a/hooks/pre/30-upgrade.rb
+++ b/hooks/pre/30-upgrade.rb
@@ -40,6 +40,14 @@ def migrate_foreman
   Kafo::Helpers.execute('foreman-rake db:migrate')
 end
 
+def remove_nodes_importers
+  Kafo::Helpers.execute("mongo pulp_database --eval 'db.repo_importers.remove({'importer_type_id': \"nodes_http_importer\"});'")
+end
+
+def remove_nodes_distributors
+  Kafo::Helpers.execute("mongo pulp_database --eval  'db.repo_distributors.remove({'distributor_type_id': \"nodes_http_distributor\"});'")
+end
+
 def upgrade_step(step)
   noop = app_value(:noop) ? ' (noop)' : ''
 
@@ -57,18 +65,26 @@ end
 
 if app_value(:upgrade)
   Kafo::Helpers.log_and_say :info, 'Upgrading...'
+  katello = Kafo::Helpers.module_enabled?(@kafo, 'katello')
+  capsule = @kafo.param('foreman_proxy_plugin_pulp', 'pulpnode_enabled').value
+
   upgrade_step :stop_services
   upgrade_step :start_databases
 
-  if Kafo::Helpers.module_enabled?(@kafo, 'katello') || @kafo.param('capsule', 'pulp').value
+  if katello || capsule
     upgrade_step :migrate_pulp
     upgrade_step :start_httpd
   end
 
-  if Kafo::Helpers.module_enabled?(@kafo, 'katello')
+  if capsule
+    upgrade_step :remove_nodes_importers
+  end
+
+  if katello
     upgrade_step :migrate_candlepin
     upgrade_step :migrate_foreman
     upgrade_step :migrate_gutterball
+    upgrade_step :remove_nodes_distributors
   end
 
   Kafo::Helpers.log_and_say :info, 'Upgrade Step: Running installer...'


### PR DESCRIPTION
This removes node importers from repositories on a capsule and node distributors from repositories on the main katello server as they are no longer needed because of the [nodes removal work that has been done.](https://github.com/Katello/katello/pull/5778)