### PR TITLE
fixes #14416 - Add katello-installer/capsule-installer to inform user of new installer

### DIFF
--- a/bin/capsule-installer
+++ b/bin/capsule-installer
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "ERROR: capsule-installer is no longer used.  Please use 'foreman-installer --scenario capsule'."
+echo "       For more information on available options, include '--help'."
+
+exit 1

--- a/bin/katello-installer
+++ b/bin/katello-installer
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "ERROR: katello-installer is no longer used.  Please use 'foreman-installer --scenario katello'."
+echo "       For more information on available options, include '--help'."
+
+exit 1


### PR DESCRIPTION
This commit contains 2 small changes to help aide users in moving to the
new installer.  Rather than remove the old commands, we will include them;
however, simply echo the new command and exit with an error code.