### PR TITLE
Fixes #14978 - capsule-certs-generate does not honour "--parent-fqdn" parameter

### DIFF
--- a/hooks/post/10-post_install.rb
+++ b/hooks/post/10-post_install.rb
@@ -17,7 +17,7 @@ end
 
 if [0,2].include?(@kafo.exit_code)
   if !app_value(:upgrade)
-    fqdn = Facter.value(:fqdn)
+    fqdn = @kafo.param('capsule_certs','parent_fqdn').value || Facter.value(:fqdn)
 
     say "  <%= color('Success!', :good) %>"
 


### PR DESCRIPTION
capsule-certs-generate does not honour "--parent-fqdn" parameter 

The parent fqdn is set as the actual hostname of the satellite server where we execute capsule-certs-generate command.