### PR TITLE
fixes #15014 - don't start mongo in reset hook

### DIFF
--- a/hooks/pre/10-reset_feature.rb
+++ b/hooks/pre/10-reset_feature.rb
@@ -50,7 +50,6 @@ def reset_pulp
     'service-wait httpd stop',
     'service-wait mongod stop',
     'rm -f /var/lib/mongodb/pulp_database*',
-    'service-wait mongod start',
     'rm -rf /var/lib/pulp/{distributions,published,repos}/*'
   ]
 


### PR DESCRIPTION
Leaving mongo stopped will trigger database migration.  Currently reset
is failing because the database is never migrated on the reset case.

Requires https://github.com/Katello/puppet-pulp/pull/145