### PR TITLE
fixes #15063 - Set answers for foreman client certs

### DIFF
--- a/config/answers.sam-installer.yaml
+++ b/config/answers.sam-installer.yaml
@@ -19,6 +19,9 @@ foreman:
   server_ssl_key: /etc/pki/katello/private/katello-apache.key
   server_ssl_ca: /etc/pki/katello/certs/katello-default-ca.crt
   server_ssl_chain: /etc/pki/katello/certs/katello-default-ca.crt
+  client_ssl_cert: /etc/pki/katello/certs/katello-apache.crt
+  client_ssl_key: /etc/pki/katello/private/katello-apache.key
+  client_ssl_ca: /etc/pki/katello/certs/katello-default-ca.crt
   websockets_encrypt: true
   websockets_ssl_key: /etc/pki/katello/private/katello-apache.key
   websockets_ssl_cert: /etc/pki/katello/certs/katello-apache.crt

--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -18,6 +18,9 @@ foreman:
   server_ssl_ca: /etc/pki/katello/certs/katello-default-ca.crt
   server_ssl_chain: /etc/pki/katello/certs/katello-default-ca.crt
   server_ssl_crl: false
+  client_ssl_cert: /etc/pki/katello/certs/katello-apache.crt
+  client_ssl_key: /etc/pki/katello/private/katello-apache.key
+  client_ssl_ca: /etc/pki/katello/certs/katello-default-ca.crt
   websockets_encrypt: true
   websockets_ssl_key: /etc/pki/katello/private/katello-apache.key
   websockets_ssl_cert: /etc/pki/katello/certs/katello-apache.crt

--- a/config/katello.migrations/160516145300-foreman-client-certs.rb
+++ b/config/katello.migrations/160516145300-foreman-client-certs.rb
@@ -1,0 +1,4 @@
+answers['foreman'] = {} unless answers['foreman'].is_a?(Hash)
+answers['foreman']['client_ssl_cert'] = '/etc/pki/katello/certs/katello-apache.crt'
+answers['foreman']['client_ssl_key'] = '/etc/pki/katello/private/katello-apache.key'
+answers['foreman']['client_ssl_ca'] = '/etc/pki/katello/certs/katello-default-ca.crt'


### PR DESCRIPTION
https://github.com/theforeman/puppet-foreman/commit/ec8c6c25356429b01cd590158932664271db387e exposes the foreman client certificates through parameters. Since Katello wants to change these from puppet to custom handling, these must be set. puppet-certs currently attempts to do so through foreman-rake config. Since puppet-foreman has started to set these in settings.yaml, they can't be overridden anymore. By setting these in the answers file, we avoid that conflict.

Note I didn't test this yet, but I believe this will become a problem so I opened this to track it.