### PR TITLE
Fixes #15072 - RHEL 6 http conf doesn't have conf.d dir structure

### DIFF
--- a/hooks/pre/30-upgrade.rb
+++ b/hooks/pre/30-upgrade.rb
@@ -11,8 +11,9 @@ def start_httpd
 end
 
 def update_http_conf
-  Kafo::Helpers.execute("grep -q -F 'Include \"/etc/httpd/conf.modules.d/*.conf\"' /etc/httpd/conf/httpd.conf || \
-		         echo 'Include \"/etc/httpd/conf.modules.d/*.conf\"' >> /etc/httpd/conf/httpd.conf")
+  Kafo::Helpers.execute("grep -F -q 'Include \"/etc/httpd/conf.modules.d/*.conf\"' /etc/httpd/conf/httpd.conf || \
+                       echo -e '<IfVersion >= 2.4> \n    Include \"/etc/httpd/conf.modules.d/*.conf\"\n</IfVersion>' \
+                       >> /etc/httpd/conf/httpd.conf")
 end
 
 def migrate_candlepin


### PR DESCRIPTION
RHEL 6 uses http 2.2 which does not have the conf.d/ directory structure. adding 
```Include "/etc/httpd/conf.modules.d/*.conf"``` causes errors in RHEL 6.

This adds a check for http 2.4 in the http.conf, which will only include the conf.d/ directory in RHEL 7 systems