### PR TITLE
Fixes #15117 - Pre script to handle setting/unsetting of pulp oauth

### DIFF
--- a/hooks/post/30-upgrade.rb
+++ b/hooks/post/30-upgrade.rb
@@ -40,6 +40,10 @@ def remove_docker_v1_content
   Kafo::Helpers.execute('foreman-rake katello:upgrades:3.0:delete_docker_v1_content')
 end
 
+def unset_pulp_oauth
+  Kafo::Helpers.execute('foreman-rake -- config -k use_pulp_oauth -v false')
+end
+
 def upgrade_step(step, options = {})
   noop = app_value(:noop) ? ' (noop)' : ''
   long_running = options[:long_running] ? ' (this may take a while) ' : ''
@@ -60,6 +64,7 @@ if app_value(:upgrade)
   upgrade_step :restart_services
 
   if Kafo::Helpers.module_enabled?(@kafo, 'katello')
+    upgrade_step :unset_pulp_oauth
     upgrade_step :db_seed
     upgrade_step :import_package_groups, :long_running => true
     upgrade_step :import_rpms, :long_running => true

--- a/hooks/pre/30-upgrade.rb
+++ b/hooks/pre/30-upgrade.rb
@@ -45,10 +45,8 @@ def migrate_pulp
   Kafo::Helpers.execute('su - apache -s /bin/bash -c pulp-manage-db')
 end
 
-def migrate_foreman
-  Kafo::Helpers.execute('foreman-rake -- config -k use_pulp_oauth -v true')
-  Kafo::Helpers.execute('foreman-rake db:migrate')
-  Kafo::Helpers.execute('foreman-rake -- config -k use_pulp_oauth -v false')
+def set_pulp_oauth
+    Kafo::Helpers.execute('foreman-rake -- config -k use_pulp_oauth -v true')
 end
 
 def remove_nodes_importers
@@ -95,9 +93,9 @@ if app_value(:upgrade)
   if katello
     upgrade_step :migrate_candlepin
     upgrade_step :start_tomcat
-    upgrade_step :migrate_foreman
     upgrade_step :migrate_gutterball
     upgrade_step :remove_nodes_distributors
+    upgrade_step :set_pulp_oauth
   end
 
   Kafo::Helpers.log_and_say :info, 'Upgrade Step: Running installer...'


### PR DESCRIPTION
One of the things that changed after katello 2.4 was the removal of
oauth. To enable a smooth transtition we need to change the upgrade
scripts to do the following

1) Set pulp to use Oauth
2) Complete the migration via -> https://github.com/theforeman/puppet-foreman/blob/master/manifests/database.pp#L29 .
3) Unset the use of pulp oauth after migration so that it uses the pulp cert auth before seeding

This commit tries to achieve that