### PR TITLE
Fixes #15117 - Upgrade steps required for 2.3 to 3.0

### DIFF
--- a/hooks/pre/30-upgrade.rb
+++ b/hooks/pre/30-upgrade.rb
@@ -10,6 +10,14 @@ def start_httpd
   Kafo::Helpers.execute('katello-service start --only httpd')
 end
 
+def start_qpidd
+  Kafo::Helpers.execute('katello-service start --only qpidd,qdrouterd')
+end
+
+def start_pulp
+  Kafo::Helpers.execute('katello-service start --only pulp_workers,pulp_resource_manager,pulp_celerybeat')
+end
+
 def update_http_conf
   Kafo::Helpers.execute("grep -q -F 'Include \"/etc/httpd/conf.modules.d/*.conf\"' /etc/httpd/conf/httpd.conf || \
 		         echo 'Include \"/etc/httpd/conf.modules.d/*.conf\"' >> /etc/httpd/conf/httpd.conf")
@@ -59,6 +67,24 @@ def remove_nodes_distributors
   Kafo::Helpers.execute("mongo pulp_database --eval  'db.repo_distributors.remove({'distributor_type_id': \"nodes_http_distributor\"});'")
 end
 
+def fix_pulp_httpd_conf
+  return true unless File.exist?('/etc/httpd/conf.d/pulp.conf.rpmnew')
+
+  Kafo::Helpers.execute('cp /etc/httpd/conf.d/pulp.conf.rpmnew /etc/httpd/conf.d/pulp.conf')
+end
+
+def fix_katello_settings_file
+  settings_file = '/etc/foreman/plugins/katello.yaml'
+  settings = JSON.parse(JSON.dump(YAML.load_file(settings_file)), :symbolize_names => true)
+
+  return true unless settings.key?(:common)
+
+  settings = {:katello => settings[:common]}
+  File.open(settings_file, 'w') do |file|
+    file.write(settings.to_yaml)
+  end
+end
+
 def upgrade_step(step)
   noop = app_value(:noop) ? ' (noop)' : ''
 
@@ -85,7 +111,10 @@ if app_value(:upgrade)
 
   if katello || capsule
     upgrade_step :migrate_pulp
+    upgrade_step :fix_pulp_httpd_conf
     upgrade_step :start_httpd
+    upgrade_step :start_qpidd
+    upgrade_step :start_pulp
   end
 
   if capsule
@@ -95,6 +124,7 @@ if app_value(:upgrade)
   if katello
     upgrade_step :migrate_candlepin
     upgrade_step :start_tomcat
+    upgrade_step :fix_katello_settings_file
     upgrade_step :migrate_foreman
     upgrade_step :migrate_gutterball
     upgrade_step :remove_nodes_distributors


### PR DESCRIPTION
This is an alternative approach to #338 where I am centralizing all the "unique" logic required for these upgrades into the pre-upgrade script and attempting to provide as much idempotent behavior as possible. Another approach would be to add "upgrade.d" functionality similar to migrations and mark upgrades that have run and perform these there. 

Note: This is only from a 2.3 to 3.0 upgrade which we say we support currently. There is one outstanding issue with this that I did not include a fix for yet. The Foreman PR (https://github.com/theforeman/foreman/pull/3519) is not currently in 1.11 and the migrations fail because of it. As I see it our options then are:

 1) Push to get https://github.com/theforeman/foreman/pull/3519 into 1.11.3 and wait for GA until then
 2) Add upgrade instructions that do the following (and yes this worked testing locally):
   - disable katello as a gem
   - run foreman-rake db:migrate to migrate Foreman
   - renable katello as a gem
   - re-run foreman-rake db:migrate to migrate Katello
 2) Require users to upgrade to 2.4 and then to 3.0