### PR TITLE
fixes #15158 - support multiple paths for katello-certs-check

### DIFF
--- a/hooks/pre/20-certs_update.rb
+++ b/hooks/pre/20-certs_update.rb
@@ -1,7 +1,7 @@
 require 'fileutils'
 
 SSL_BUILD_DIR = '/root/ssl-build/'
-CHECK_SCRIPT  = File.expand_path('../../../bin/katello-certs-check', __FILE__)
+CHECK_SCRIPT = `which katello-certs-check`.strip
 
 def error(message)
   logger.error message


### PR DESCRIPTION
katello-certs-check is either in the katello-installer directory
(git repo) or in foreman-installer-katello (rpm install).  This supports
both cases.

For 3.1, would it just make sense to combine these into 2 packages? I wasn't sure if there's a technical reason for why we keep foreman-installer-katello and katello-installer-base as 2 separate packages.