### PR TITLE
Fixes #15205: Add migration creator script

### DIFF
--- a/bin/create-migration
+++ b/bin/create-migration
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+if ARGV.length != 2
+  puts "Please specify a directory to create the migration in and the name of the migration (e.g. create-migration config/katello.migrations add-server-ssl-crl"
+  exit 1
+end
+
+directory = ARGV[0]
+migration_name = ARGV[1]
+timestamp = `date +%y%m%d%H%M%S`.strip
+
+File.open("#{directory}/#{timestamp}-#{migration_name}.rb", 'w') do |file|
+  file.write('')
+end


### PR DESCRIPTION
Basic migration generator script that ensure the proper timestamp
formatted file is created in the place you want it.