### PR TITLE
Fixes #15203: Set server_ssl_crl to false through migration

### DIFF
--- a/config/katello.migrations/160526130623-server-ssl-crl.rb
+++ b/config/katello.migrations/160526130623-server-ssl-crl.rb
@@ -1,0 +1,1 @@
+answers['foreman']['server_ssl_crl'] = false


### PR DESCRIPTION
In some upgrade scenarios, this field is not being set during the
legacy migration step.