### PR TITLE
fixes #14858 - remove gutterball directory

### DIFF
--- a/hooks/post/30-upgrade.rb
+++ b/hooks/post/30-upgrade.rb
@@ -43,6 +43,7 @@ end
 def remove_gutterball
   return true unless Kafo::Helpers.execute('rpm -q gutterball')
   Kafo::Helpers.execute("rpm -e gutterball tfm-rubygem-foreman_gutterball gutterball-certs tfm-rubygem-hammer_cli_gutterball")
+  Kafo::Helpers.execute("rmdir /var/lib/tomcat/webapps/gutterball")
 end
 
 def upgrade_step(step, options = {})


### PR DESCRIPTION
One small thing I found in testing  upgrade w/ gutterball removal.  The gutterball dir isn't removed.  It's empty, but Tomcat still tries to "deploy" it:

```
May 27 16:39:44 centos7-2-4.example.com server[10839]: INFO: Deploying web application directory /var/lib/tomcat/webapps/gutterball
```