### PR TITLE
Fixes #15241 - fail nicely if puppet certs were already generated

### DIFF
--- a/hooks/pre_commit/05-puppet_certs_exist.rb
+++ b/hooks/pre_commit/05-puppet_certs_exist.rb
@@ -1,0 +1,28 @@
+def error(message)
+  say message
+  logger.error message
+  kafo.class.exit 101
+end
+
+def param_value(mod, name)
+  param(mod, name).value if param(mod, name)
+end
+
+puppet_ca_enabled = param_value('foreman_proxy', 'puppetca')
+server_crl_path = param_value('foreman', 'server_ssl_crl')
+cert_dir = param_value('foreman_proxy', 'ssldir')
+key_path = param_value('foreman_proxy', 'puppet_ssl_key')
+puppet_ca_cert = param_value('foreman_proxy', 'puppet_ssl_ca')
+puppet_enabled = param_value('foreman_proxy', 'puppet')
+
+client_message = "- is Puppet already installed without Puppet CA? You can remove the existing certificates with 'rm -rf #{cert_dir}' to get Puppet CA properly configured."
+
+if puppet_ca_enabled && key_path && File.exists?(key_path) && !kafo.skip_checks_i_know_better?
+  if !puppet_ca_cert.empty? && !File.exists?(puppet_ca_cert)
+    error "The file #{puppet_ca_cert} does not exist.\n #{client_message}\n" \
+    " - if you use custom Puppet SSL directory (--foreman-proxy-ssldir) make sure the directory exists and contain the CA certificate.\n"
+  end
+  if server_crl_path.is_a?(String) && !server_crl_path.empty? && !File.exists?(server_crl_path)
+    error "The file #{server_crl_path} does not exist.\n #{client_message}\n - if you set custom revocation list (--foreman-server-ssl-crl) make sure the file exists."
+  end
+end


### PR DESCRIPTION
As long as installer hooks are not shared yet among Katello and Foreman scenarios I'm proposing the same hook as in https://github.com/theforeman/foreman-installer/pull/149 also to Katello.

Issue: Puppet is not able to generate proper CA certificates when the client certificate was already generated.
Solution: The installer stops and informs user about the conflicting situation possible causes and fixes

-  the checks are only performed when server CA is true
-  existence of puppet client cert is tested on existence of host priv key
-   the checks can be skipped with --skip-checks-i-know-better switch
