### PR TITLE
Fixes #14956 - Check for proxy before katello-installer runs

### DIFF
--- a/checks/proxy.rb
+++ b/checks/proxy.rb
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+# checking to see if http/https proxy envs are set before running the installer
+
+http_proxy = ENV['http_proxy']
+https_proxy = ENV['https_proxy']
+
+PROXYSET = "Please unset the http_proxy and/or https_proxy environment variables before running the installer"
+
+def error_exit(message, code)
+  $stderr.puts message
+  exit code
+end
+
+error_exit(PROXYSET, 1) if http_proxy != nil || https_proxy != nil


### PR DESCRIPTION
Created proxy check for katello-installer to verify if a proxy env is set.