### PR TITLE
fixes #15297: post upgrade to update puppet repositories

### DIFF
--- a/hooks/post/30-upgrade.rb
+++ b/hooks/post/30-upgrade.rb
@@ -40,6 +40,10 @@ def remove_docker_v1_content
   Kafo::Helpers.execute('foreman-rake katello:upgrades:3.0:delete_docker_v1_content')
 end
 
+def update_puppet_repository_distributors
+  Kafo::Helpers.execute('foreman-rake katello:upgrades:3.0:update_puppet_repository_distributors')
+end
+
 def remove_gutterball
   return true unless Kafo::Helpers.execute('rpm -q gutterball')
   Kafo::Helpers.execute("yum erase -y gutterball tfm-rubygem-foreman_gutterball gutterball-certs tfm-rubygem-hammer_cli_gutterball")
@@ -78,6 +82,7 @@ if app_value(:upgrade)
     upgrade_step :import_subscriptions, :long_running => true
     upgrade_step :elasticsearch_message
     upgrade_step :remove_docker_v1_content, :long_running => true
+    upgrade_step :update_puppet_repository_distributors, :long_running => true
     upgrade_step :remove_gutterball
   end
 


### PR DESCRIPTION
This commit includes a post upgrade task to perform
updates to the puppet repositories (e.g associate
puppet distributor & publish).