### PR TITLE
fixes #15315: update capsule foreman url & trusted hosts

### DIFF
--- a/config/capsule.migrations/160601202256-additional-foreman-proxy.rb
+++ b/config/capsule.migrations/160601202256-additional-foreman-proxy.rb
@@ -1,0 +1,25 @@
+def move(name, default=nil, new_name=nil)
+  answers['foreman_proxy'][(new_name || name)] = answers['capsule'].delete(name) { |k| default }
+end
+
+# migrate from legacy capsule, if exists
+if answers['capsule'].is_a? Hash
+  unless answers['capsule']['parent_fqdn'].nil?
+    answers['foreman_proxy']['trusted_hosts'] ||= []
+    answers['foreman_proxy']['trusted_hosts'] << answers['capsule']['parent_fqdn']
+    answers['foreman_proxy']['trusted_hosts'].uniq!
+    answers['foreman_proxy']['foreman_base_url'] = "https://#{answers['capsule']['parent_fqdn']}"
+  end
+
+  move('foreman_oauth_key', 'admin', 'oauth_consumer_key')
+  move('foreman_oauth_secret', 'admin', 'oauth_consumer_secret')
+end
+
+# migrate from legacy certs, if exists
+if answers['certs'].is_a? Hash
+  unless answers['certs']['node_fqdn'].nil?
+    answers['foreman_proxy']['trusted_hosts'] ||= []
+    answers['foreman_proxy']['trusted_hosts'] << answers['certs']['node_fqdn']
+    answers['foreman_proxy']['trusted_hosts'].uniq!
+  end
+end

--- a/hooks/pre_migrations/01-migrate_legacy_foreman_installer_config.rb
+++ b/hooks/pre_migrations/01-migrate_legacy_foreman_installer_config.rb
@@ -13,7 +13,7 @@ if File.exists?(legacy_config_file)
     scenario = Kafo::Configuration.new(scenario_file)
 
     # copy over config and answers
-    scenario.migrate_configuration(legacy_config)
+    scenario.migrate_configuration(legacy_config, :skip => [:log_dir, :log_name])
     scenario.store(legacy_config.answers)
 
     # link last used scenario

--- a/hooks/pre_migrations/10-migrate_legacy_capsule_config.rb
+++ b/hooks/pre_migrations/10-migrate_legacy_capsule_config.rb
@@ -13,7 +13,7 @@ if File.exists?(legacy_config_file)
     scenario = Kafo::Configuration.new(scenario_file)
 
     # copy over config and answers
-    scenario.migrate_configuration(legacy_config)
+    scenario.migrate_configuration(legacy_config, :skip => [:log_dir, :log_name])
     scenario.store(legacy_config.answers)
 
     # link last used scenario

--- a/hooks/pre_migrations/11-migrate_legacy_katello_config.rb
+++ b/hooks/pre_migrations/11-migrate_legacy_katello_config.rb
@@ -13,7 +13,7 @@ if File.exists?(legacy_config_file)
     scenario = Kafo::Configuration.new(scenario_file)
 
     # copy over config and answers
-    scenario.migrate_configuration(legacy_config)
+    scenario.migrate_configuration(legacy_config, :skip => [:log_dir, :log_name])
     scenario.store(legacy_config.answers)
 
     # link last used scenario


### PR DESCRIPTION
This commit will ensure that during a capsule upgrade
that the foreman url and trusted hosts are populated
correctly from the legacy capsule configuration.

In addition, a change is being introduced to keep the
default log_dir and log_name from the new configurations
versus from the old (e.g. /v/l/capsule-installer).  This
was the intended behavior and is what is used by some
downstreams.