### PR TITLE
Fixes #15325 - Handle nil params

### DIFF
--- a/hooks/post/10-post_install.rb
+++ b/hooks/post/10-post_install.rb
@@ -19,7 +19,7 @@ installer_name = kafo.config.app[:installer_name] || kafo.invocation_path
 
 if [0,2].include?(@kafo.exit_code)
   if !app_value(:upgrade)
-    fqdn = @kafo.param('capsule_certs','parent_fqdn').value || Facter.value(:fqdn)
+    fqdn = @kafo.param('capsule_certs','parent_fqdn').try(:value) || Facter.value(:fqdn)
 
     say "  <%= color('Success!', :good) %>"
 


### PR DESCRIPTION
for 'capsule_certs' and 'parent_fqdn'

BATs are failing with `/usr/share/katello-installer-base/hooks/post/10-post_install.rb:22:in `block (4 levels) in load': undefined method `value' for nil:NilClass (NoMethodError)`

This was introduced in #332.