### PR TITLE
Fixes #15346 - Guess what is running from scenario name

### DIFF
--- a/bin/capsule-certs-generate
+++ b/bin/capsule-certs-generate
@@ -31,6 +31,7 @@ CONFIG_CONTENT = <<EOF
 :answer_file: #{answers_file.path}
 :installer_dir: #{INSTALLER_DIR}
 :installer_name: 'foreman-installer'
+:product_name: 'Katello'
 :module_dirs: ["/usr/share/foreman-installer/modules", "#{INSTALLER_DIR}/modules"]
 :hook_dirs: ["#{INSTALLER_DIR}/hooks"]
 :default_values_dir: /tmp

--- a/config/capsule.yaml
+++ b/config/capsule.yaml
@@ -1,6 +1,7 @@
 ---
   :name: Capsule
   :description: Install a stand-alone Capsule.
+  :product_name: Katello
   :log_dir: /var/log/foreman-installer
   :log_name: capsule.log
   :log_level: DEBUG

--- a/config/katello-devel.yaml
+++ b/config/katello-devel.yaml
@@ -1,6 +1,7 @@
 ---
   :name: Katello devel
   :description:
+  :product_name: Katello
   :log_dir: /var/log/foreman-installer
   :log_name: katello-devel.log
   :log_level: DEBUG

--- a/config/katello.yaml
+++ b/config/katello.yaml
@@ -1,6 +1,7 @@
 ---
   :name: Katello
   :description: Install Foreman with Katello
+  :product_name: Katello
   :log_dir: /var/log/foreman-installer
   :log_name: katello.log
   :log_level: DEBUG

--- a/hooks/boot/01-helpers.rb
+++ b/hooks/boot/01-helpers.rb
@@ -34,5 +34,9 @@ class Kafo::Helpers
 
       !results.include? false
     end
+
+    def product_name
+      ::Kafo::KafoConfigure.config.app[:product_name] || 'Katello'
+    end
   end
 end

--- a/hooks/boot/10-reset_hook.rb
+++ b/hooks/boot/10-reset_hook.rb
@@ -2,7 +2,7 @@
 app_option(
   '--reset',
   :flag,
-  "This option will drop the Katello database and clear all subsequent backend data stores." +
+  "This option will drop the #{Kafo::Helpers.product_name} database and clear all subsequent backend data stores." +
   "You will lose all data! Unfortunately we\n" +
   "can't detect a failure at the moment so you should verify the success\n" +
   'manually. e.g. dropping can fail when DB is currently in use.',

--- a/hooks/post/10-post_install.rb
+++ b/hooks/post/10-post_install.rb
@@ -29,7 +29,7 @@ if [0,2].include?(@kafo.exit_code)
 
     # Fortello UI?
     if Kafo::Helpers.module_enabled?(@kafo, 'katello')
-      say "  * <%= color('Katello', :info) %> is running at <%= color('#{@kafo.param('foreman','foreman_url').value}', :info) %>"
+      say "  * <%= color('#{Kafo::Helpers.product_name}', :info) %> is running at <%= color('#{@kafo.param('foreman','foreman_url').value}', :info) %>"
       say "      Initial credentials are <%= color('#{@kafo.param('foreman', 'admin_username').value}', :info) %> / <%= color('#{@kafo.param('foreman', 'admin_password').value}', :info) %>" if @kafo.param('foreman','authentication').value == true && new_install?
     end
 
@@ -53,7 +53,7 @@ MSG
 
   To finish the installation, follow these steps:
 
-  If you do not have the smartproxy registered to the Katello instance, then please do the following:
+  If you do not have the smartproxy registered to the #{Kafo::Helpers.product_name} instance, then please do the following:
 
   1. yum -y localinstall http://#{fqdn}/pub/katello-ca-consumer-latest.noarch.rpm
   2. subscription-manager register --org "<%= color('#{org}', :info) %>"

--- a/hooks/post/30-upgrade.rb
+++ b/hooks/post/30-upgrade.rb
@@ -47,7 +47,7 @@ end
 def remove_gutterball
   return true unless Kafo::Helpers.execute('rpm -q gutterball')
   Kafo::Helpers.execute("yum erase -y gutterball tfm-rubygem-foreman_gutterball gutterball-certs tfm-rubygem-hammer_cli_gutterball")
-  
+
   ['tomcat', 'tomcat6'].each do |t|
     gutterball_dir = "/var/lib/#{t}/webapps/gutterball"
     Kafo::Helpers.execute("rmdir #{gutterball_dir}") if File.directory?(gutterball_dir)
@@ -87,6 +87,6 @@ if app_value(:upgrade)
   end
 
   if [0,2].include? @kafo.exit_code
-    Kafo::Helpers.log_and_say :info, 'Katello upgrade completed!'
+    Kafo::Helpers.log_and_say :info, "#{Kafo::Helpers.product_name} upgrade completed!"
   end
 end

--- a/hooks/pre/10-reset_feature.rb
+++ b/hooks/pre/10-reset_feature.rb
@@ -1,5 +1,4 @@
 # See bottom of the script for the command that kicks off the script
-
 def reset
   if foreman_installed?
 
@@ -9,7 +8,7 @@ def reset
     reset_pulp
 
   else
-    Kafo::KafoConfigure.logger.warn 'Katello not installed yet, can not drop database!'
+    Kafo::KafoConfigure.logger.warn "#{Kafo::Helpers.product_name} not installed yet, can not drop database!"
   end
 end
 
@@ -58,4 +57,3 @@ def reset_pulp
 end
 
 reset if app_value(:reset) && !app_value(:noop)
-

--- a/hooks/pre_validations/10-check_capsule_pulp.rb
+++ b/hooks/pre_validations/10-check_capsule_pulp.rb
@@ -6,7 +6,7 @@ end
 
 if param('capsule', 'pulp') && param('capsule', 'pulp').value
   if system("rpm -q katello &>/dev/null")
-    error "the pulp node can't be installed on a machine with Katello master"
+    error "the pulp node can't be installed on a machine with #{Kafo::Helpers.product_name} master"
   end
 
   if system("(rpm -q ipa-server || rpm -q freeipa-server) &>/dev/null")
@@ -14,6 +14,6 @@ if param('capsule', 'pulp') && param('capsule', 'pulp').value
   end
 
   unless system("subscription-manager identity &>/dev/null && ! grep -q subscription.rhn.redhat.com /etc/rhsm/rhsm.conf &> /dev/null")
-    error "The system has to be registered to a Katello instance before installing the node"
+    error "The system has to be registered to a #{Kafo::Helpers.product_name} instance before installing the node"
   end
 end


### PR DESCRIPTION
This patch should allow us to be more precise about what is running in post install message. E.g.:
```text
[root@sat-snap-rhel7 ~]# foreman-installer --scenario satellite
Installing             Done                                               [100%] [...............................................................................................................................]
  Success!
  * Satellite is running at https://sat-snap-rhel7.example.com
  * To install additional capsule on separate machine continue by running:

      capsule-certs-generate --capsule-fqdn "$CAPSULE" --certs-tar "~/$CAPSULE-certs.tar"

  The full log is at /var/log/foreman-installer/satellite.log
```