### PR TITLE
fixes #15350: add migrations for capsule -> foreman_proxy separation

### DIFF
--- a/config/capsule.migrations/160608111430-additional-foreman-proxy.rb
+++ b/config/capsule.migrations/160608111430-additional-foreman-proxy.rb
@@ -1,0 +1,44 @@
+def move(name, new_name=nil, default=nil)
+  answers['foreman_proxy'][(new_name || name)] = answers['capsule'].delete(name) { |k| default }
+end
+
+# migrate addtional fields from the legacy capsule configuration to foreman_proxy
+if answers['capsule'].is_a? Hash
+  move('bmc', 'bmc')
+  move('bmc_default_provider', 'bmc_default_provider')
+  move('dhcp', 'dhcp')
+  move('dhcp_listen_on', 'dhcp_listen_on')
+  move('dhcp_option_domain', 'dhcp_option_domain')
+  move('dhcp_interface', 'dhcp_interface')
+  move('dhcp_gateway', 'dhcp_gateway')
+  move('dhcp_managed', 'dhcp_managed')
+  move('dhcp_range', 'dhcp_range')
+  move('dhcp_nameservers', 'dhcp_nameservers')
+  move('dhcp_vendor', 'dhcp_vendor')
+  move('dhcp_config', 'dhcp_config')
+  move('dhcp_leases', 'dhcp_leases')
+  move('dhcp_key_name', 'dhcp_key_name')
+  move('dhcp_key_secret', 'dhcp_key_secret')
+  move('dns', 'dns')
+  move('dns_managed', 'dns_managed')
+  move('dns_provider', 'dns_provider')
+  move('dns_zone', 'dns_zone')
+  move('dns_reverse', 'dns_reverse')
+  move('dns_interface', 'dns_interface')
+  move('dns_server', 'dns_server')
+  move('dns_ttl', 'dns_ttl')
+  move('dns_tsig_keytab', 'dns_tsig_keytab')
+  move('dns_tsig_principal', 'dns_tsig_principal')
+  move('dns_forwarders', 'dns_forwarders')
+  move('virsh_network', 'virsh_network')
+  move('realm', 'realm')
+  move('realm_provider', 'realm_provider')
+  move('realm_keytab', 'realm_keytab')
+  move('realm_principal', 'realm_principal')
+  move('freeipa_remove_dns', 'freeipa_remove_dns')
+  move('register_in_foreman', 'register_in_foreman')
+
+  if answers['certs'].is_a?(Hash) && !answers['certs']['node_fqdn'].nil?
+    answers['foreman_proxy']['registered_proxy_url'] = "https://#{answers['certs']['node_fqdn']}:#{answers['foreman_proxy']['ssl_port']}"
+  end
+end

--- a/config/katello-devel.migrations/160601202256-additional-foreman-proxy.rb
+++ b/config/katello-devel.migrations/160601202256-additional-foreman-proxy.rb
@@ -1,0 +1,25 @@
+def move(name, default=nil, new_name=nil)
+  answers['foreman_proxy'][(new_name || name)] = answers['capsule'].delete(name) { |k| default }
+end
+
+# migrate from legacy capsule, if exists
+if answers['capsule'].is_a? Hash
+  unless answers['capsule']['parent_fqdn'].nil?
+    answers['foreman_proxy']['trusted_hosts'] ||= []
+    answers['foreman_proxy']['trusted_hosts'] << answers['capsule']['parent_fqdn']
+    answers['foreman_proxy']['trusted_hosts'].uniq!
+    answers['foreman_proxy']['foreman_base_url'] = "https://#{answers['capsule']['parent_fqdn']}"
+  end
+
+  move('foreman_oauth_key', 'admin', 'oauth_consumer_key')
+  move('foreman_oauth_secret', 'admin', 'oauth_consumer_secret')
+end
+
+# migrate from legacy certs, if exists
+if answers['certs'].is_a? Hash
+  unless answers['certs']['node_fqdn'].nil?
+    answers['foreman_proxy']['trusted_hosts'] ||= []
+    answers['foreman_proxy']['trusted_hosts'] << answers['certs']['node_fqdn']
+    answers['foreman_proxy']['trusted_hosts'].uniq!
+  end
+end

--- a/config/katello-devel.migrations/160608111430-additional-foreman-proxy.rb
+++ b/config/katello-devel.migrations/160608111430-additional-foreman-proxy.rb
@@ -1,0 +1,44 @@
+def move(name, new_name=nil, default=nil)
+  answers['foreman_proxy'][(new_name || name)] = answers['capsule'].delete(name) { |k| default }
+end
+
+# migrate addtional fields from the legacy capsule configuration to foreman_proxy
+if answers['capsule'].is_a? Hash
+  move('bmc', 'bmc')
+  move('bmc_default_provider', 'bmc_default_provider')
+  move('dhcp', 'dhcp')
+  move('dhcp_listen_on', 'dhcp_listen_on')
+  move('dhcp_option_domain', 'dhcp_option_domain')
+  move('dhcp_interface', 'dhcp_interface')
+  move('dhcp_gateway', 'dhcp_gateway')
+  move('dhcp_managed', 'dhcp_managed')
+  move('dhcp_range', 'dhcp_range')
+  move('dhcp_nameservers', 'dhcp_nameservers')
+  move('dhcp_vendor', 'dhcp_vendor')
+  move('dhcp_config', 'dhcp_config')
+  move('dhcp_leases', 'dhcp_leases')
+  move('dhcp_key_name', 'dhcp_key_name')
+  move('dhcp_key_secret', 'dhcp_key_secret')
+  move('dns', 'dns')
+  move('dns_managed', 'dns_managed')
+  move('dns_provider', 'dns_provider')
+  move('dns_zone', 'dns_zone')
+  move('dns_reverse', 'dns_reverse')
+  move('dns_interface', 'dns_interface')
+  move('dns_server', 'dns_server')
+  move('dns_ttl', 'dns_ttl')
+  move('dns_tsig_keytab', 'dns_tsig_keytab')
+  move('dns_tsig_principal', 'dns_tsig_principal')
+  move('dns_forwarders', 'dns_forwarders')
+  move('virsh_network', 'virsh_network')
+  move('realm', 'realm')
+  move('realm_provider', 'realm_provider')
+  move('realm_keytab', 'realm_keytab')
+  move('realm_principal', 'realm_principal')
+  move('freeipa_remove_dns', 'freeipa_remove_dns')
+  move('register_in_foreman', 'register_in_foreman')
+
+  if answers['certs'].is_a?(Hash) && !answers['certs']['node_fqdn'].nil?
+    answers['foreman_proxy']['registered_proxy_url'] = "https://#{answers['certs']['node_fqdn']}:#{answers['foreman_proxy']['ssl_port']}"
+  end
+end

--- a/config/katello.migrations/160601202256-additional-foreman-proxy.rb
+++ b/config/katello.migrations/160601202256-additional-foreman-proxy.rb
@@ -1,0 +1,25 @@
+def move(name, default=nil, new_name=nil)
+  answers['foreman_proxy'][(new_name || name)] = answers['capsule'].delete(name) { |k| default }
+end
+
+# migrate from legacy capsule, if exists
+if answers['capsule'].is_a? Hash
+  unless answers['capsule']['parent_fqdn'].nil?
+    answers['foreman_proxy']['trusted_hosts'] ||= []
+    answers['foreman_proxy']['trusted_hosts'] << answers['capsule']['parent_fqdn']
+    answers['foreman_proxy']['trusted_hosts'].uniq!
+    answers['foreman_proxy']['foreman_base_url'] = "https://#{answers['capsule']['parent_fqdn']}"
+  end
+
+  move('foreman_oauth_key', 'admin', 'oauth_consumer_key')
+  move('foreman_oauth_secret', 'admin', 'oauth_consumer_secret')
+end
+
+# migrate from legacy certs, if exists
+if answers['certs'].is_a? Hash
+  unless answers['certs']['node_fqdn'].nil?
+    answers['foreman_proxy']['trusted_hosts'] ||= []
+    answers['foreman_proxy']['trusted_hosts'] << answers['certs']['node_fqdn']
+    answers['foreman_proxy']['trusted_hosts'].uniq!
+  end
+end

--- a/config/katello.migrations/160608111430-additional-foreman-proxy.rb
+++ b/config/katello.migrations/160608111430-additional-foreman-proxy.rb
@@ -1,0 +1,44 @@
+def move(name, new_name=nil, default=nil)
+  answers['foreman_proxy'][(new_name || name)] = answers['capsule'].delete(name) { |k| default }
+end
+
+# migrate addtional fields from the legacy capsule configuration to foreman_proxy
+if answers['capsule'].is_a? Hash
+  move('bmc', 'bmc')
+  move('bmc_default_provider', 'bmc_default_provider')
+  move('dhcp', 'dhcp')
+  move('dhcp_listen_on', 'dhcp_listen_on')
+  move('dhcp_option_domain', 'dhcp_option_domain')
+  move('dhcp_interface', 'dhcp_interface')
+  move('dhcp_gateway', 'dhcp_gateway')
+  move('dhcp_managed', 'dhcp_managed')
+  move('dhcp_range', 'dhcp_range')
+  move('dhcp_nameservers', 'dhcp_nameservers')
+  move('dhcp_vendor', 'dhcp_vendor')
+  move('dhcp_config', 'dhcp_config')
+  move('dhcp_leases', 'dhcp_leases')
+  move('dhcp_key_name', 'dhcp_key_name')
+  move('dhcp_key_secret', 'dhcp_key_secret')
+  move('dns', 'dns')
+  move('dns_managed', 'dns_managed')
+  move('dns_provider', 'dns_provider')
+  move('dns_zone', 'dns_zone')
+  move('dns_reverse', 'dns_reverse')
+  move('dns_interface', 'dns_interface')
+  move('dns_server', 'dns_server')
+  move('dns_ttl', 'dns_ttl')
+  move('dns_tsig_keytab', 'dns_tsig_keytab')
+  move('dns_tsig_principal', 'dns_tsig_principal')
+  move('dns_forwarders', 'dns_forwarders')
+  move('virsh_network', 'virsh_network')
+  move('realm', 'realm')
+  move('realm_provider', 'realm_provider')
+  move('realm_keytab', 'realm_keytab')
+  move('realm_principal', 'realm_principal')
+  move('freeipa_remove_dns', 'freeipa_remove_dns')
+  move('register_in_foreman', 'register_in_foreman')
+
+  if answers['certs'].is_a?(Hash) && !answers['certs']['node_fqdn'].nil?
+    answers['foreman_proxy']['registered_proxy_url'] = "https://#{answers['certs']['node_fqdn']}:#{answers['foreman_proxy']['ssl_port']}"
+  end
+end


### PR DESCRIPTION
With the Katello on Foreman feature, there was an effort to separate
the foreman_proxy aspects from the puppet-capsule.  The changes
for this were primarily done as part of:
	https://github.com/Katello/puppet-capsule/pull/64

At that time, there were no migration capabilities to move the
answers from the 'capsule' to 'foreman_proxy' within the various
answer files (e.g. answers.katello-installer.yaml &
answers.capsule-installer.yaml).

This commit will add in migrations for each env to support moving
the parameters over.  This includes:
- katello
- katello-devel
- capsule

It should be noted that for katello and katello-devel include
an additional migration.  It is one that was added in a previous
commit for capsule, but it should apply to all environments.