### PR TITLE
Fixes #15390: Ignore empty answers during Capsule to Proxy migration

### DIFF
--- a/config/katello.migrations/160120212701-foreman-proxy.rb
+++ b/config/katello.migrations/160120212701-foreman-proxy.rb
@@ -50,6 +50,7 @@ answers['foreman_proxy::plugin::pulp'] = {
 }
 
 def move(name, default=nil, new_name=nil)
+  return unless answers['capsule'].key?(name)
   answers['foreman_proxy'][(new_name || name)] = answers['capsule'].delete(name) { |k| default }
 end
 

--- a/config/katello.migrations/160601202256-additional-foreman-proxy.rb
+++ b/config/katello.migrations/160601202256-additional-foreman-proxy.rb
@@ -1,4 +1,5 @@
 def move(name, default=nil, new_name=nil)
+  return unless answers['capsule'].key?(name)
   answers['foreman_proxy'][(new_name || name)] = answers['capsule'].delete(name) { |k| default }
 end
 

--- a/config/katello.migrations/160608111430-additional-foreman-proxy.rb
+++ b/config/katello.migrations/160608111430-additional-foreman-proxy.rb
@@ -1,4 +1,5 @@
 def move(name, new_name=nil, default=nil)
+  return unless answers['capsule'].key?(name)
   answers['foreman_proxy'][(new_name || name)] = answers['capsule'].delete(name) { |k| default }
 end
 


### PR DESCRIPTION
Without this check, answers not found already (such as a new
installation) are set to nil instead of the default values provided
by the puppet module.