### PR TITLE
Fixes #15660: Print command output during upgrade steps in debug color

### DIFF
--- a/hooks/boot/01-helpers.rb
+++ b/hooks/boot/01-helpers.rb
@@ -7,7 +7,15 @@ class Kafo::Helpers
     end
 
     def log_and_say(level, message)
-      style = level == :error ? 'bad' : level
+      style = case level
+              when :error
+                'bad'
+              when :debug
+                'yellow'
+              else
+                level
+              end
+
       say "<%= color('#{message}', :#{style}) %>"
       Kafo::KafoConfigure.logger.send(level, message)
     end
@@ -24,10 +32,10 @@ class Kafo::Helpers
         output = `#{command} 2>&1`
 
         if $?.success?
-          ::Kafo::KafoConfigure.logger.debug output.to_s
+          log_and_say(:debug, output.to_s)
           results << true
         else
-         ::Kafo::KafoConfigure.logger.error output.to_s
+          log_and_say(:error, output.to_s)
           results << false
         end
       end


### PR DESCRIPTION
This is especially useful for Pulp migrations as they contain useful
information regarding what stage they are at and if they will be long
running.