### PR TITLE
Fixes #15696 - Added memory check to installer

### DIFF
--- a/hooks/boot/17-disable_system_checks.rb
+++ b/hooks/boot/17-disable_system_checks.rb
@@ -1,0 +1,7 @@
+# Add disable system checks option
+app_option(
+  '--disable-system-checks',
+  :flag,
+  "This option will skip the system checks for memory.",
+  :default => false
+)

--- a/hooks/pre/17-memory_check.rb
+++ b/hooks/pre/17-memory_check.rb
@@ -1,0 +1,11 @@
+# call grep and awk to store total ram and define min ram
+total_ram = `grep MemTotal /proc/meminfo | awk '{print $2}'`.to_i
+min_ram = 8_388_608
+
+# call mem_check if flag is called
+if app_value(:disable_system_checks)
+  logger.warn 'Skipping system checks.'
+elsif min_ram > total_ram
+  $stderr.puts 'This system has less than 8 GB of total memory. Please have at least 8 GB of total ram free before running the installer.'
+  kafo.class.exit(1)
+end


### PR DESCRIPTION
Added memory check to installer to make sure system has decent ram before running the installer.