### PR TITLE
Fixes #15775 - Use absolute paths instead of relative.

### DIFF
--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -12,16 +12,16 @@ HELP
 while getopts "c:k:r:b:" opt; do
     case $opt in
         c)
-            CERT_FILE="$OPTARG"
+            CERT_FILE="$(readlink -f $OPTARG)"
             ;;
         k)
-            KEY_FILE="$OPTARG"
+            KEY_FILE="$(readlink -f $OPTARG)"
             ;;
         r)
-            REQ_FILE="$OPTARG"
+            REQ_FILE="$(readlink -f $OPTARG)"
             ;;
         b)
-            CA_BUNDLE_FILE="$OPTARG"
+            CA_BUNDLE_FILE="$(readlink -f $OPTARG)"
             ;;
         h)
             usage


### PR DESCRIPTION
Switching to absolute paths to avoid issues with validate_absolute_path
during upgrades.
Fixes #15775

New format
--------------
```
...
Validation succeeded.

To install the Satellite main server with the custom certificates, run:

    satellite-installer --scenario satellite\
                        --certs-server-cert "/root/sat_cert/test.crt"\
                        --certs-server-cert-req "/root/sat_cert/test.crt.req"\
                        --certs-server-key "/root/sat_cert/test.key"\
                        --certs-server-ca-cert "/root/sat_cert/cacert.crt"
...
```