### PR TITLE
fixes #15911 - don't use facter anymore in the installer

### DIFF
--- a/checks/hostname.rb
+++ b/checks/hostname.rb
@@ -1,25 +1,15 @@
 #!/usr/bin/env ruby
 
-begin
-  require 'rubygems'
-rescue LoadError
-end
-require 'facter'
-
-BASE = %q(If needed, change the hostname permanently via 'hostname' command and editing 
+BASE = %q(If needed, change the hostname permanently via 'hostname' command and editing
 appropriate configuration file.
 (e.g. on Red Hat systems /etc/sysconfig/network).
 
 If 'hostname -f' still returns unexpected result, check /etc/hosts and put
 hostname entry in the correct order, for example:
- 
-  1.2.3.4 full.hostname.com full
- 
-Fully qualified hostname must be the first entry on the line)
 
-DIFFERENT = %q(Output of 'facter fqdn' is different from 'hostname -f'
- 
-Make sure above command gives the same output. )
+  1.2.3.4 full.hostname.com full
+
+Fully qualified hostname must be the first entry on the line)
 
 INVALID = %q(Output of 'hostname -f' does not seems to be valid FQDN
 
@@ -29,18 +19,14 @@ dot must be present and underscores are not allowed. )
 UPCASE = %q(The hostname contains a capital letter.
 
 This is not supported. Please modify the hostname to be all lowercase. )
- 
 
 def error_exit(message, code)
   $stderr.puts message
   exit code
 end
 
-fqdn = Facter.value(:fqdn)
+fqdn = `hostname -f`
 
-# Check that facter actually has a value that matches the hostname.
-# This should always be true for facter >= 1.7
-error_exit(DIFFERENT + BASE, 1) if fqdn != `hostname -f`.chomp
 # Every FQDN should have at least one dot
 error_exit(INVALID + BASE, 2) unless fqdn.include?('.')
 # Per https://bugzilla.redhat.com/show_bug.cgi?id=1205960 check for underscores

--- a/hooks/post/10-post_install.rb
+++ b/hooks/post/10-post_install.rb
@@ -22,7 +22,7 @@ if [0,2].include?(@kafo.exit_code)
     fqdn = if @kafo.param('capsule_certs','parent_fqdn')
              @kafo.param('capsule_certs', 'parent_fqdn').value
            else
-             Facter.value(:fqdn)
+             `hostname -f`
            end
 
     say "  <%= color('Success!', :good) %>"


### PR DESCRIPTION
Facter is bundled in the AIO bundle and not accessible to system ruby.  We can just call `hostname -f` anyway.