### PR TITLE
Fixes #15380 - remove ssl.conf before installer run

### DIFF
--- a/hooks/pre/29-remove_sslconf.rb
+++ b/hooks/pre/29-remove_sslconf.rb
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+# check if file exists and if so remove it
+
+File.delete("/etc/httpd/conf.d/ssl.conf") if File.file?("/etc/httpd/conf.d/ssl.conf")


### PR DESCRIPTION
added a hook to remove "/etc/httpd/conf.d/ssl.conf" which was causing issues with --upgrade being run if the mod_ssl package was upgraded replacing the ssl.conf config file.