### PR TITLE
Fixes #16011 - handle both puppet 3 and 4 dirs when cleaning

### DIFF
--- a/hooks/boot/12-clear_puppet_environments.rb
+++ b/hooks/boot/12-clear_puppet_environments.rb
@@ -2,6 +2,6 @@
 app_option(
   '--clear-puppet-environments',
   :flag,
-  'This option will clear all Puppet environments from disk located in \'/etc/puppet/environments/\'.',
+  'This option will clear all published Puppet environments from disk.',
   :default => false
 )

--- a/hooks/pre/12-clear_puppet_environments_feature.rb
+++ b/hooks/pre/12-clear_puppet_environments_feature.rb
@@ -1,11 +1,16 @@
 # See bottom of the script for the command that kicks off the script
 
+PUPPET_THREE_ENV_DIR = '/etc/puppet/environments'
+PUPPET_FOUR_ENV_DIR = '/etc/puppetlabs/code/environments'
+
 def clear_puppet_environments
-  if File.directory?('/etc/puppet/environments')
-    `rm -rf /etc/puppet/environments/*`
-    Kafo::KafoConfigure.logger.info 'Puppet environment data successfully removed.'
-  else
-    Kafo::KafoConfigure.logger.warn 'Puppet environment data directory not present at \'/etc/puppet/environments\''
+  [PUPPET_THREE_ENV_DIR, PUPPET_FOUR_ENV_DIR].each do |env_dir|
+    if File.directory?(env_dir)
+      `rm -rf #{File.join(env_dir, '*')}`
+      Kafo::KafoConfigure.logger.info "Puppet environment data successfully removed from #{env_dir}."
+    else
+      Kafo::KafoConfigure.logger.info "Puppet environment data directory not present at #{env_dir}."
+    end
   end
 end
 


### PR DESCRIPTION
Previously, the clear puppet environments flag would only clear the
puppet 3 dir. This patch iterates over both the puppet 3 and puppet 4
dirs, cleaning both if the flag is set.