### PR TITLE
Fixes #16053: hooks for puppet 4 upgrade

### DIFF
--- a/hooks/boot/31-upgrade-puppet.rb
+++ b/hooks/boot/31-upgrade-puppet.rb
@@ -1,0 +1,6 @@
+app_option(
+  '--upgrade-puppet',
+  :flag,
+  "Run the steps neccessary to upgrade from Puppet 3 to Puppet 4.",
+  :default => false
+)

--- a/hooks/post/31-upgrade-puppet.rb
+++ b/hooks/post/31-upgrade-puppet.rb
@@ -1,0 +1,33 @@
+def restart_services
+  Kafo::Helpers.execute('katello-service restart')
+end
+
+def upgrade_step(step, options = {})
+  noop = app_value(:noop) ? ' (noop)' : ''
+  long_running = options[:long_running] ? ' (this may take a while) ' : ''
+
+  Kafo::Helpers.log_and_say :info, "Upgrade Step: #{step}#{long_running}#{noop}..."
+  unless app_value(:noop)
+    status = send(step)
+    fail_and_exit "Upgrade step #{step} failed. Check logs for more information." unless status
+  end
+end
+
+def fail_and_exit(message)
+  Kafo::Helpers.log_and_say :error, message
+  kafo.class.exit 1
+end
+
+if app_value(:upgrade_puppet)
+
+  katello = Kafo::Helpers.module_enabled?(@kafo, 'katello')
+  capsule = @kafo.param('foreman_proxy_plugin_pulp', 'pulpnode_enabled').value
+
+  if katello || capsule
+    upgrade_step :restart_services
+  end
+
+  if [0, 2].include? @kafo.exit_code
+    Kafo::Helpers.log_and_say :info, 'Puppet upgrade completed!'
+  end
+end

--- a/hooks/pre/30-upgrade.rb
+++ b/hooks/pre/30-upgrade.rb
@@ -94,6 +94,9 @@ def fail_and_exit(message)
 end
 
 if app_value(:upgrade)
+  fail_and_exit 'Concurrent use of --upgrade and --upgrade-puppet is not supported. '\
+                'Please run --upgrade first, then --upgrade-puppet.' if app_value(:upgrade_puppet)
+
   Kafo::Helpers.log_and_say :info, 'Upgrading...'
   katello = Kafo::Helpers.module_enabled?(@kafo, 'katello')
   capsule = @kafo.param('foreman_proxy_plugin_pulp', 'pulpnode_enabled').value

--- a/hooks/pre/31-upgrade-puppet.rb
+++ b/hooks/pre/31-upgrade-puppet.rb
@@ -1,0 +1,69 @@
+def puppet4_available?
+  success = []
+  success << Kafo::Helpers.execute('yum info puppet-agent')
+  success << Kafo::Helpers.execute('yum info puppetserver')
+  !success.include?(false)
+end
+
+def stop_services
+  Kafo::Helpers.execute('katello-service stop')
+end
+
+def upgrade_puppet_package
+  Kafo::Helpers.execute('yum remove -y puppet-server')
+  Kafo::Helpers.execute('yum install -y puppetserver')
+  Kafo::Helpers.execute('yum install -y puppet-agent')
+end
+
+def copy_data
+  success = []
+  success << Kafo::Helpers.execute('cp -rfp /etc/puppet/environments/* /etc/puppetlabs/code/environments') if File.directory?('/etc/puppet/environments')
+  success << Kafo::Helpers.execute('mv /var/lib/puppet/ssl /etc/puppetlabs/puppet') if File.directory?('/var/lib/puppet/ssl')
+  success << Kafo::Helpers.execute('mv /var/lib/puppet/foreman_cache_data /opt/puppetlabs/puppet/cache/') if File.directory?('/var/lib/puppet/foreman_cache_data')
+  !success.include?(false)
+end
+
+def upgrade_step(step)
+  noop = app_value(:noop) ? ' (noop)' : ''
+
+  Kafo::Helpers.log_and_say :info, "Upgrade Step: #{step}#{noop}..."
+  unless app_value(:noop)
+    status = send(step)
+    fail_and_exit "Upgrade step #{step} failed. Check logs for more information." unless status
+  end
+end
+
+def fail_and_exit(message)
+  Kafo::Helpers.log_and_say :error, message
+  kafo.class.exit 1
+end
+
+def reset_value(param)
+  unless app_value(:noop)
+    param.value = param.default unless param.nil?
+  end
+end
+
+if app_value(:upgrade_puppet)
+  katello = Kafo::Helpers.module_enabled?(@kafo, 'katello')
+  capsule = @kafo.param('foreman_proxy_plugin_pulp', 'pulpnode_enabled').value
+
+  fail_and_exit 'Puppet 3 to 4 upgrade is not currently supported for the chosen scenario.' unless katello || capsule
+
+  Kafo::Helpers.log_and_say :info, 'Upgrading puppet...'
+  fail_and_exit 'Unable to find Puppet 4 packages, is the repository enabled?' unless puppet4_available?
+
+  reset_value(param('foreman', 'puppet_home'))
+  reset_value(param('foreman', 'puppet_ssldir'))
+  reset_value(param('foreman_proxy', 'puppet_ssl_ca'))
+  reset_value(param('foreman_proxy', 'puppet_ssl_cert'))
+  reset_value(param('foreman_proxy', 'puppet_ssl_key'))
+  reset_value(param('foreman_proxy', 'puppetdir'))
+  reset_value(param('foreman_proxy', 'ssldir'))
+
+  upgrade_step :upgrade_puppet_package
+  upgrade_step :stop_services
+  upgrade_step :copy_data
+
+  Kafo::Helpers.log_and_say :info, "Puppet 3 to 4 upgrade initialization complete, continuing with installation"
+end


### PR DESCRIPTION
This enables a `--upgrade-puppet` flag that will upgrade a Katello
installation from Puppet 3 to Puppet 4.

Most of this is based on
http://projects.theforeman.org/projects/foreman/wiki/Upgrading_from_Puppet_3_to_4
and https://github.com/beav/forklift/pull/1.

todo (feel free to add/subtract from this):

- [x] bail out before we start mucking with configs:
 - [x] exit early if puppet 4 packages are not available
 - [x] ensure directories we are copying from and to are readable/writable
- [x] test capsule
