### PR TITLE
Refs #16354 - Hardcoding ruby version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,8 @@
 inherit_from: .rubocop_todo.yml
 
+AllCops:
+  TargetRubyVersion: 2.0
+
 HashSyntax:
   Enabled: false # don't force 1.9 hash syntax
 


### PR DESCRIPTION
People using Ruby 2.3.0 are getting a different set of rubocop warnings/errors when they run rubocop locally. This change will prevent that. Using Ruby version 2.0 based on https://git.io/viZBa.