### PR TITLE
fixes #16929 - make hostname check message clearer

### DIFF
--- a/checks/hostname.rb
+++ b/checks/hostname.rb
@@ -1,13 +1,9 @@
 #!/usr/bin/env ruby
 
-BASE = %q(If needed, change the hostname permanently via 'hostname' command and editing
-appropriate configuration file.
-(e.g. on Red Hat systems /etc/sysconfig/network).
+BASE = %q(If 'hostname -f' still returns unexpected result, check /etc/hosts
+and put the hostname entry in the correct order, for example:
 
-If 'hostname -f' still returns unexpected result, check /etc/hosts and put
-hostname entry in the correct order, for example:
-
-  1.2.3.4 full.hostname.com full
+  1.2.3.4 hostname.example.com hostname
 
 Fully qualified hostname must be the first entry on the line)
 


### PR DESCRIPTION
BZ reporter was unhappy with the format of the /etc/hosts suggestion, so this makes it a little more clearer I guess about what's expected.

Also, the way to set the hostname of el6 and el7 is different, and who knows could change again in el8. Users should read the docs on how to do it.