### PR TITLE
fixes #17138 - fix rubocop failure

### DIFF
--- a/hooks/pre/30-upgrade.rb
+++ b/hooks/pre/30-upgrade.rb
@@ -135,8 +135,10 @@ def fail_and_exit(message)
 end
 
 if app_value(:upgrade)
-  fail_and_exit 'Concurrent use of --upgrade and --upgrade-puppet is not supported. '\
-                'Please run --upgrade first, then --upgrade-puppet.' if app_value(:upgrade_puppet)
+  if app_value(:upgrade_puppet)
+    fail_and_exit 'Concurrent use of --upgrade and --upgrade-puppet is not supported. '\
+                  'Please run --upgrade first, then --upgrade-puppet.'
+  end
 
   Kafo::Helpers.log_and_say :info, 'Upgrading...'
   katello = Kafo::Helpers.module_enabled?(@kafo, 'katello')


### PR DESCRIPTION
Rubocop is unhappy 

```
hooks/pre/30-upgrade.rb:138:3: C: Favor a normal if-statement over a modifier clause in a multiline statement.

fail_and_exit 'Concurrent use of --upgrade and --upgrade-puppet is not supported. '\ ...

^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

```