### PR TITLE
Fixes #16864 - remove gutterball webapp directory

### DIFF
--- a/hooks/post/30-upgrade.rb
+++ b/hooks/post/30-upgrade.rb
@@ -62,7 +62,7 @@ def remove_gutterball
 
   ['tomcat', 'tomcat6'].each do |t|
     gutterball_dir = "/var/lib/#{t}/webapps/gutterball"
-    Kafo::Helpers.execute("rmdir #{gutterball_dir}") if File.directory?(gutterball_dir)
+    Kafo::Helpers.execute("rm -rfv #{gutterball_dir}") if File.directory?(gutterball_dir)
   end
 end
 


### PR DESCRIPTION
Still seeing web app dir after upgrades:

For upgrades from 6.1, that directory remains undeleted, so tomcat still deploys gutterball app despite no gutterball RPM present, no gutterball DB. And that still subscribes to the $(fqdn):event qpid queue and still causes https://access.redhat.com/solutions/2608341 - confirmed in field already.

Switching to an rm -rfv to make sure we remove the dir 100%