### PR TITLE
Fixes #16863 - Remove qpid event queue

### DIFF
--- a/hooks/pre/30-upgrade.rb
+++ b/hooks/pre/30-upgrade.rb
@@ -92,15 +92,6 @@ def fix_katello_settings_file
   end
 end
 
-def remove_event_queue
-  queue_present = `qpid-stat -q --ssl-certificate=/etc/pki/katello/qpid_client_striped.crt -b amqps://localhost:5671 | grep :event | wc -l`.chomp.to_i
-  if queue_present > 0
-    Kafo::Helpers.execute('qpid-config --ssl-certificate=/etc/pki/katello/qpid_client_striped.crt -b amqps://localhost:5671 del queue $(hostname -f):event --force')
-  else
-    logger.info 'Event queue is already removed, skipping'
-  end
-end
-
 def mark_qpid_cert_for_update
   hostname = param('certs', 'node_fqdn').value
 
@@ -179,7 +170,6 @@ if app_value(:upgrade)
   if katello
     upgrade_step :mark_qpid_cert_for_update
     upgrade_step :migrate_candlepin, :run_always => true
-    upgrade_step :remove_event_queue
     upgrade_step :remove_gutterball
     upgrade_step :start_tomcat, :run_always => true
     upgrade_step :fix_katello_settings_file


### PR DESCRIPTION
Finding on some upgrades the event queue is still present, removing from pre and moving to post. 