### PR TITLE
Fixes #17124 - install capsule parser cache

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,12 +28,14 @@ end
 task :generate_parser_caches => [PARSER_CACHE_DIR] do
   caches = [
     "#{PARSER_CACHE_DIR}/katello.yaml",
+    "#{PARSER_CACHE_DIR}/capsule.yaml",
     "#{PARSER_CACHE_DIR}/katello-devel.yaml",
     "#{PARSER_CACHE_DIR}/capsule-certs-generate.yaml"
   ]
 
   configs = [
     'config/katello.yaml',
+    'config/capsule.yaml',
     'config/katello-devel.yaml'
   ]
 

--- a/config/capsule.yaml
+++ b/config/capsule.yaml
@@ -8,13 +8,133 @@
   :answer_file: "./config/capsule-answers.yaml"
   :installer_dir: "."
   :default_values_dir: "/tmp"
-  :module_dirs: ["/usr/share/foreman/modules", "./modules"]
+  :module_dirs: ["./_build/modules", "../katello-installer/modules"]
   :parser_cache_path:
     - /usr/share/foreman-installer/parser_cache/foreman.yaml
     - /usr/share/katello-installer-base/parser_cache/katello.yaml
+    - /usr/share/katello-installer-base/parser_cache/capsule.yaml
   :hiera_config: /usr/share/foreman-installer/config/foreman-hiera.conf
   :hook_dirs: ["./hooks"]
   :colors: true
   :order:
     - certs
     - capsule
+  :mapping:
+    :foreman::cli:
+      :dir_name: foreman
+      :manifest_name: cli
+      :params_name: cli/params
+    :foreman::plugin::bootdisk:
+      :dir_name: foreman
+      :manifest_name: plugin/bootdisk
+    :foreman::plugin::cockpit:
+      :dir_name: foreman
+      :manifest_name: plugin/cockpit
+    :foreman::plugin::puppetdb:
+      :dir_name: foreman
+      :params_name: plugin/puppetdb/params
+      :manifest_name: plugin/puppetdb
+    :foreman::plugin::hooks:
+      :dir_name: foreman
+      :manifest_name: plugin/hooks
+    :foreman::plugin::dhcp_browser:
+      :dir_name: foreman
+      :manifest_name: plugin/dhcp_browser
+    :foreman::plugin::digitalocean:
+      :dir_name: foreman
+      :manifest_name: plugin/digitalocean
+    :foreman::plugin::discovery:
+      :dir_name: foreman
+      :manifest_name: plugin/discovery
+      :params_name: plugin/discovery/params
+    :foreman::plugin::docker:
+      :dir_name: foreman
+      :manifest_name: plugin/docker
+    :foreman::plugin::memcache:
+      :dir_name: foreman
+      :manifest_name: plugin/memcache
+      :params_name: plugin/memcache/params
+    :foreman::plugin::openscap:
+      :dir_name: foreman
+      :params_name: plugin/openscap/params
+      :manifest_name: plugin/openscap
+    :foreman::plugin::ovirt_provision:
+      :dir_name: foreman
+      :params_name: plugin/ovirt_provision/params
+      :manifest_name: plugin/ovirt_provision
+    :foreman::plugin::chef:
+      :dir_name: foreman
+      :manifest_name: plugin/chef
+    :foreman::plugin::tasks:
+      :dir_name: foreman
+      :params_name: plugin/tasks/params
+      :manifest_name: plugin/tasks
+    :foreman::plugin::templates:
+      :dir_name: foreman
+      :manifest_name: plugin/templates
+    :foreman::plugin::remote_execution:
+      :dir_name: foreman
+      :manifest_name: plugin/remote_execution
+      :params_name: plugin/remote_execution/params
+    :foreman::plugin::salt:
+      :dir_name: foreman
+      :manifest_name: plugin/salt
+    :foreman::plugin::setup:
+      :dir_name: foreman
+      :manifest_name: plugin/setup
+    :foreman::plugin::default_hostgroup:
+      :dir_name: foreman
+      :manifest_name: plugin/default_hostgroup
+    :foreman::compute::rackspace:
+      :dir_name: foreman
+      :manifest_name: compute/rackspace
+    :foreman::compute::openstack:
+      :dir_name: foreman
+      :manifest_name: compute/openstack
+    :foreman::compute::vmware:
+      :dir_name: foreman
+      :manifest_name: compute/vmware
+    :foreman::compute::libvirt:
+      :dir_name: foreman
+      :manifest_name: compute/libvirt
+    :foreman::compute::ec2:
+      :dir_name: foreman
+      :manifest_name: compute/ec2
+    :foreman::compute::gce:
+      :dir_name: foreman
+      :manifest_name: compute/gce
+    :foreman::compute::ovirt:
+      :dir_name: foreman
+      :manifest_name: compute/ovirt
+    :foreman_proxy::plugin::abrt:
+      :manifest_name: plugin/abrt
+      :params_name: plugin/abrt/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::chef:
+      :manifest_name: plugin/chef
+      :params_name: plugin/chef/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::dns::powerdns:
+      :manifest_name: plugin/dns/powerdns
+      :params_name: plugin/dns/powerdns/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::dynflow:
+      :manifest_name: plugin/dynflow
+      :params_name: plugin/dynflow/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::openscap:
+      :manifest_name: plugin/openscap
+      :params_name: plugin/openscap/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::pulp:
+      :manifest_name: plugin/pulp
+      :params_name: plugin/pulp/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::remote_execution::ssh:
+      :manifest_name: plugin/remote_execution/ssh
+      :params_name: plugin/remote_execution/ssh/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::salt:
+      :manifest_name: plugin/salt
+      :params_name: plugin/salt/params
+      :dir_name: foreman_proxy


### PR DESCRIPTION
There were some fixes in master for capsule parser cache, this commit is a
smaller version to just pull what's needed to build the capsule parser cache
for puppet 4.