### PR TITLE
Fixes #17124 - install capsule parser cache

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,12 +28,14 @@ end
 task :generate_parser_caches => [PARSER_CACHE_DIR] do
   caches = [
     "#{PARSER_CACHE_DIR}/katello.yaml",
+    "#{PARSER_CACHE_DIR}/capsule.yaml",
     "#{PARSER_CACHE_DIR}/katello-devel.yaml",
     "#{PARSER_CACHE_DIR}/capsule-certs-generate.yaml"
   ]
 
   configs = [
     'config/katello.yaml',
+    'config/capsule.yaml',
     'config/katello-devel.yaml'
   ]
 

--- a/config/capsule.yaml
+++ b/config/capsule.yaml
@@ -8,13 +8,47 @@
   :answer_file: "./config/capsule-answers.yaml"
   :installer_dir: "."
   :default_values_dir: "/tmp"
-  :module_dirs: ["/usr/share/foreman/modules", "./modules"]
+  :module_dirs: ["./_build/modules", "../katello-installer/modules"]
   :parser_cache_path:
     - /usr/share/foreman-installer/parser_cache/foreman.yaml
     - /usr/share/katello-installer-base/parser_cache/katello.yaml
+    - /usr/share/katello-installer-base/parser_cache/capsule.yaml
   :hiera_config: /usr/share/foreman-installer/config/foreman-hiera.conf
   :hook_dirs: ["./hooks"]
   :colors: true
   :order:
     - certs
     - capsule
+  :mapping:
+    :foreman_proxy::plugin::abrt:
+      :manifest_name: plugin/abrt
+      :params_name: plugin/abrt/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::chef:
+      :manifest_name: plugin/chef
+      :params_name: plugin/chef/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::dns::powerdns:
+      :manifest_name: plugin/dns/powerdns
+      :params_name: plugin/dns/powerdns/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::dynflow:
+      :manifest_name: plugin/dynflow
+      :params_name: plugin/dynflow/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::openscap:
+      :manifest_name: plugin/openscap
+      :params_name: plugin/openscap/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::pulp:
+      :manifest_name: plugin/pulp
+      :params_name: plugin/pulp/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::remote_execution::ssh:
+      :manifest_name: plugin/remote_execution/ssh
+      :params_name: plugin/remote_execution/ssh/params
+      :dir_name: foreman_proxy
+    :foreman_proxy::plugin::salt:
+      :manifest_name: plugin/salt
+      :params_name: plugin/salt/params
+      :dir_name: foreman_proxy


### PR DESCRIPTION
There were some fixes in master for capsule parser cache, this commit
is a smaller version to just pull what's needed to build the capsule
parser cache for puppet 4.