### PR TITLE
fixes #17278 - add group: foreman to certs

### DIFF
--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -2,6 +2,7 @@
 certs:
   generate: true
   deploy: true
+  group: foreman
 katello:
   package_names:
   - katello


### PR DESCRIPTION
When syncing the migrations with the answers, I accidentally
removed `group: foreman` from the certs top-level module.  Since
there's no migration that sets the value (it was there since the
beginning) no migration added it back.