### PR TITLE
Fixes #17331 - supress el6 qpid-stat traceback

### DIFF
--- a/hooks/post/30-upgrade.rb
+++ b/hooks/post/30-upgrade.rb
@@ -69,7 +69,7 @@ end
 def remove_event_queue
   queue_present = `qpid-stat -q --ssl-certificate=/etc/pki/katello/qpid_client_striped.crt -b amqps://localhost:5671 | grep :event | wc -l`.chomp.to_i
   if queue_present > 0
-    Kafo::Helpers.execute('qpid-config --ssl-certificate=/etc/pki/katello/qpid_client_striped.crt -b amqps://localhost:5671 del queue $(hostname -f):event --force')
+    Kafo::Helpers.execute('qpid-config --ssl-certificate=/etc/pki/katello/qpid_client_striped.crt -b amqps://localhost:5671 del queue $(hostname -f):event --force > /dev/null 2>&1')
   else
     logger.info 'Event queue is already removed, skipping'
   end


### PR DESCRIPTION
Fixes this issue that is related to qpid, its not every upgrade or time either. This happens after an upgrade with a manual qpid-stat from the cli too. The queue gets removed just it gives a nasty traceback to the user during the upgrade process. I talked with @mccun934 and he is fine with just suppressing the error. Also added '' around my grep.

Traceback that appears during upgrade is at the bottom of the paste below:

https://paste.fedoraproject.org/483909/40169014/