### PR TITLE
fixes #17415 - remove unmanaged httpd conf files

### DIFF
--- a/hooks/post/11-create_sslconf.rb
+++ b/hooks/post/11-create_sslconf.rb
@@ -1,7 +1,0 @@
-# post hook to create an ssl.conf file to work-around this issue http://projects.theforeman.org/issues/16972 until mod_ssl packging is fixed.
-
-if File.file?('/etc/httpd/conf.d/ssl.conf')
-  logger.info 'ssl.conf is already present, skipping'
-else
-  File.open('/etc/httpd/conf.d/ssl.conf', 'w') { |file| file.write("# This file is managed by the foreman-installer, do not alter.") }
-end

--- a/hooks/post/29-create_package_httpd_conf.rb
+++ b/hooks/post/29-create_package_httpd_conf.rb
@@ -1,0 +1,22 @@
+# Some packages like mod_ssl and pulp place configuration files in
+# /etc/httpd/conf.d that contain duplicates declarations of directives
+# that the puppetlabs-apache module configured elsewhere.
+#
+# * pulp places a pulp.conf that contains a duplicate WSGI 'pulp'
+#   daemon that 05-pulps-https.conf contains.
+#
+# * mod_ssl places a 'Listen 443' directive in ssl.conf that ports.conf already
+#   has.
+#
+# This hook creates placeholders files so the package does not put them
+# in place anymore.
+#
+%w(ssl.conf pulp.conf).each do |file|
+  if File.file?(File.join("/etc/httpd/conf.d/", file))
+    File.open(File.join('/etc/httpd/conf.d', file), 'w') do |f|
+      f.write("# This file is managed by the foreman-installer, do not alter.")
+    end
+  else
+    logger.info 'ssl.conf is already present, skipping'
+  end
+end

--- a/hooks/pre/29-remove_package_httpd_conf.rb
+++ b/hooks/pre/29-remove_package_httpd_conf.rb
@@ -1,0 +1,13 @@
+# Some packages like mod_ssl and pulp place configuration files in
+# /etc/httpd/conf.d that contain duplicates declarations of directives
+# that the puppetlabs-apache module configured elsewhere.
+#
+# * pulp places a pulp.conf that contains a duplicate WSGI 'pulp'
+#   daemon that 05-pulps-https.conf contains.
+#
+# * mod_ssl places a 'Listen 443' directive in ssl.conf that ports.conf already
+#   has.
+
+%w(ssl.conf pulp.conf).each do |file|
+  File.delete(File.join("/etc/httpd/conf.d/", file)) if File.file?(File.join("/etc/httpd/conf.d/", file))
+end

--- a/hooks/pre/29-remove_sslconf.rb
+++ b/hooks/pre/29-remove_sslconf.rb
@@ -1,5 +1,0 @@
-#!/usr/bin/env ruby
-
-# check if file exists and if so remove it
-
-File.delete("/etc/httpd/conf.d/ssl.conf") if File.file?("/etc/httpd/conf.d/ssl.conf")

--- a/hooks/pre/30-upgrade.rb
+++ b/hooks/pre/30-upgrade.rb
@@ -74,12 +74,6 @@ def remove_nodes_distributors
   Kafo::Helpers.execute("mongo pulp_database --eval  'db.repo_distributors.remove({'distributor_type_id': \"nodes_http_distributor\"});'")
 end
 
-def fix_pulp_httpd_conf
-  return true unless File.exist?('/etc/httpd/conf.d/pulp.conf.rpmnew')
-
-  Kafo::Helpers.execute('cp /etc/httpd/conf.d/pulp.conf.rpmnew /etc/httpd/conf.d/pulp.conf')
-end
-
 def fix_katello_settings_file
   settings_file = '/etc/foreman/plugins/katello.yaml'
   settings = JSON.parse(JSON.dump(YAML.load_file(settings_file)), :symbolize_names => true)
@@ -157,7 +151,6 @@ if app_value(:upgrade)
 
   if katello || capsule
     upgrade_step :migrate_pulp, :run_always => true
-    upgrade_step :fix_pulp_httpd_conf, :run_always => true
     upgrade_step :start_httpd, :run_always => true
     upgrade_step :start_qpidd, :run_always => true
     upgrade_step :start_pulp, :run_always => true


### PR DESCRIPTION
Like mod_ssl did, pulp package now places a pulp.conf that has a duplicate directive.