### PR TITLE
Fixes #17605: Memory check works for real 8 GB

### DIFF
--- a/hooks/pre/17-memory_check.rb
+++ b/hooks/pre/17-memory_check.rb
@@ -1,6 +1,6 @@
 # call grep and awk to store total ram and define min ram
 total_ram = `grep MemTotal /proc/meminfo | awk '{print $2}'`.to_i
-min_ram = 8_388_608
+min_ram = 7_900_000
 
 # call mem_check if flag is called
 if app_value(:disable_system_checks) || Kafo::Helpers.module_enabled?(@kafo, 'capsule_certs')


### PR DESCRIPTION
I just bought Intel NUC with 8GB module for testing Katello and apparently when
I install CentOS 7 and keep KDump feature enabled (which is the default), some
memory is reserved for this, therefore my system reports this:

```
[root@nuc ~]# free
              total        used        free      shared  buff/cache   available
Mem:        7928504      427748     4026228        9076     3474528     7150332
Swap:       7812092           0     7812092
[root@nuc ~]# grep MemTotal /proc/meminfo | awk '{print $2}'
7928504
```

This patch changes the check to accept 7.9 GB as 8 GB threshold. If this is a
problem for Katello, I will rewrite the patch and change the error message to
"Minimum 8.1 GB is required" which is really what the check does. But it's
really weird requirement, I am testing with real hardware.