### PR TITLE
fixes #17507 - remove workaround for ssl.conf

### DIFF
--- a/hooks/post/29-create_package_httpd_conf.rb
+++ b/hooks/post/29-create_package_httpd_conf.rb
@@ -1,17 +1,14 @@
-# Some packages like mod_ssl and pulp place configuration files in
-# /etc/httpd/conf.d that contain duplicates declarations of directives
-# that the puppetlabs-apache module configured elsewhere.
+# Some packages like pulp place configuration files in /etc/httpd/conf.d that
+# contain duplicates declarations of directives that the puppetlabs-apache
+# module configured elsewhere.
 #
 # * pulp places a pulp.conf that contains a duplicate WSGI 'pulp'
 #   daemon that 05-pulps-https.conf contains.
 #
-# * mod_ssl places a 'Listen 443' directive in ssl.conf that ports.conf already
-#   has.
+# This hook creates placeholders files so the package does not put them in
+# place anymore.
 #
-# This hook creates placeholders files so the package does not put them
-# in place anymore.
-#
-%w(ssl.conf pulp.conf).each do |file|
+%w(pulp.conf).each do |file|
   if !File.file?(File.join("/etc/httpd/conf.d/", file))
     File.open(File.join('/etc/httpd/conf.d', file), 'w') do |f|
       f.write("# This file is managed by the foreman-installer, do not alter.")

--- a/hooks/pre/29-remove_package_httpd_conf.rb
+++ b/hooks/pre/29-remove_package_httpd_conf.rb
@@ -1,13 +1,10 @@
-# Some packages like mod_ssl and pulp place configuration files in
-# /etc/httpd/conf.d that contain duplicates declarations of directives
-# that the puppetlabs-apache module configured elsewhere.
+# Some packages like pulp place configuration files in /etc/httpd/conf.d that
+# contain duplicates declarations of directives that the puppetlabs-apache
+# module configured elsewhere.
 #
 # * pulp places a pulp.conf that contains a duplicate WSGI 'pulp'
 #   daemon that 05-pulps-https.conf contains.
 #
-# * mod_ssl places a 'Listen 443' directive in ssl.conf that ports.conf already
-#   has.
-
-%w(ssl.conf pulp.conf).each do |file|
+%w(pulp.conf).each do |file|
   File.delete(File.join("/etc/httpd/conf.d/", file)) if File.file?(File.join("/etc/httpd/conf.d/", file))
 end


### PR DESCRIPTION
When puppetlabs-apache is released with the fix for this, we no
longer need to worry about the RPM overwriting the ssl.conf
file.

https://github.com/puppetlabs/puppetlabs-apache/pull/1543 was accepted.

This PR mostly as a reminder to myself, it'll probably bit a little while before the change appears in a released version.