### PR TITLE
fixes #17604 - correct capsule scenario module dir paths

### DIFF
--- a/config/capsule.yaml
+++ b/config/capsule.yaml
@@ -9,8 +9,8 @@
 :installer_dir: .
 :default_values_dir: /tmp
 :module_dirs:
-- /usr/share/foreman/modules
-- ./modules
+- ./_build/modules
+- ../katello-installer/modules
 :parser_cache_path:
 - /usr/share/foreman-installer/parser_cache/foreman.yaml
 - /usr/share/katello-installer-base/parser_cache/katello.yaml


### PR DESCRIPTION
/usr/share/foreman/modules isn't even a path that ever existed.  It only ever worked because it was all on one line before like this:

`:module_dirs: ['foo', 'bar']`

And the sed didn't care what the contents was, but since I added the migration tools in https://github.com/Katello/katello-installer/commit/0174992d0cf90fe577d0c8cf2d005eefe7bd2391, the YAML is outputted differently so it no longer matches the sed.

This PR makes capsule.yaml use the same config as the rest of the scenarios.