### PR TITLE
Fixes #16946 - add check to look for pulp ca

### DIFF
--- a/hooks/post/12-check_pulp_ca.rb
+++ b/hooks/post/12-check_pulp_ca.rb
@@ -1,0 +1,8 @@
+# hook to create pulp CA on EL6 if not present
+
+if File.file?('/etc/pki/pulp/ca.crt') && File.file?('/etc/pki/pulp/ca.key')
+  logger.info 'Pulp CA is already present, skipping'
+else
+  logger.warn 'Pulp CA is not present, creating.'
+  `pulp-gen-ca-certificate`
+end


### PR DESCRIPTION
Without CA Present:

  Success!
  * Satellite is running at https://rhel6.example.com
      Initial credentials are admin / NsApaaAicBfRVeoP
  * To install additional capsule on separate machine continue by running:

      capsule-certs-generate --capsule-fqdn "$CAPSULE" --certs-tar "~/$CAPSULE-certs.tar"

  The full log is at /var/log/foreman-installer/satellite.log
[ INFO 2016-12-07 23:22:10 verbose] ssl.conf is already present, skipping
[ WARN 2016-12-07 23:22:10 verbose] Pulp CA is not present, creating.
[ INFO 2016-12-07 23:22:11 verbose] All hooks in group post finished


With CA Present:

  Success!
  * Satellite is running at https://rhel6.example.com
  * To install additional capsule on separate machine continue by running:

      capsule-certs-generate --capsule-fqdn "$CAPSULE" --certs-tar "~/$CAPSULE-certs.tar"

  The full log is at /var/log/foreman-installer/satellite.log
[ INFO 2016-12-07 23:28:31 verbose] ssl.conf is already present, skipping
[ INFO 2016-12-07 23:28:31 verbose] Pulp CA is already present, skipping
[ INFO 2016-12-07 23:28:31 verbose] All hooks in group post finished

Way to test:

install EL6 Downstream:

* "hostname foo.bar.baz", ensure "hostname -f" returns "Unknown host"
* yum install satellite (not satellite-installer)
* satellite-installer --scenario satellite
* fix hostname, re-run satellite-installer
