### PR TITLE
Fixes #17975 - Suggest a valid variable name for proxy-certs-generate

### DIFF
--- a/hooks/post/10-post_install.rb
+++ b/hooks/post/10-post_install.rb
@@ -37,7 +37,7 @@ if [0, 2].include?(@kafo.exit_code)
       say <<MSG
   * To install an additional Foreman proxy on separate machine continue by running:
 
-      foreman-proxy-certs-generate --foreman-proxy-fqdn "<%= color('$FOREMAN-PROXY', :info) %>" --certs-tar "<%= color('~/$FOREMAN-PROXY-certs.tar', :info) %>"
+      foreman-proxy-certs-generate --foreman-proxy-fqdn "<%= color('$FOREMAN_PROXY', :info) %>" --certs-tar "<%= color('~/$FOREMAN_PROXY-certs.tar', :info) %>"
 
 MSG
     end


### PR DESCRIPTION
FOREMAN-PROXY isn't a valid identifier in bash because of the dash, 
so if an user copies and pastes that command, it will never work as that
variable cannot be set. It should be something like FOREMANPROXY
or FOREMAN_PROXY so users can set that variable.