### PR TITLE
fixes #18132 - hooks in --noop delete pulp.conf

### DIFF
--- a/hooks/post/29-create_package_httpd_conf.rb
+++ b/hooks/post/29-create_package_httpd_conf.rb
@@ -8,12 +8,14 @@
 # This hook creates placeholders files so the package does not put them in
 # place anymore.
 #
-%w(pulp.conf).each do |file|
-  if !File.file?(File.join("/etc/httpd/conf.d/", file))
-    File.open(File.join('/etc/httpd/conf.d', file), 'w') do |f|
-      f.write("# This file is managed by the foreman-installer, do not alter.")
+if !app_value(:noop)
+  %w(pulp.conf).each do |file|
+    if !File.file?(File.join("/etc/httpd/conf.d/", file))
+      File.open(File.join('/etc/httpd/conf.d', file), 'w') do |f|
+        f.write("# This file is managed by the foreman-installer, do not alter.")
+      end
+    else
+      logger.info "#{file} is already present, skipping"
     end
-  else
-    logger.info "#{file} is already present, skipping"
   end
 end

--- a/hooks/pre/29-remove_package_httpd_conf.rb
+++ b/hooks/pre/29-remove_package_httpd_conf.rb
@@ -1,10 +1,13 @@
-# Some packages like pulp place configuration files in /etc/httpd/conf.d that
+# Pulp places a configuration file in /etc/httpd/conf.d that
 # contain duplicates declarations of directives that the puppetlabs-apache
-# module configured elsewhere.
+# module configured elsewhere. This is only relevant on smart proxies.
+# The main katello install overwrites the pulp.conf.
 #
 # * pulp places a pulp.conf that contains a duplicate WSGI 'pulp'
 #   daemon that 05-pulps-https.conf contains.
 #
-%w(pulp.conf).each do |file|
-  File.delete(File.join("/etc/httpd/conf.d/", file)) if File.file?(File.join("/etc/httpd/conf.d/", file))
+if !Kafo::Helpers.module_enabled?(@kafo, 'katello') && !app_value(:noop)
+  %w(pulp.conf).each do |file|
+    File.delete(File.join("/etc/httpd/conf.d/", file)) if File.file?(File.join("/etc/httpd/conf.d/", file))
+  end
 end


### PR DESCRIPTION
This workaround is not needed anymore, katello now uses the pulp.conf
instead of 05-pulps-https.conf. therefore it doesn't need to delete or
create pulp.conf in hook because it overwrites pulp.conf within the
installer