### PR TITLE
Fixes #17191 - don't continue with upgrade on db migrate error

### DIFF
--- a/hooks/pre/30-upgrade.rb
+++ b/hooks/pre/30-upgrade.rb
@@ -61,9 +61,9 @@ def migrate_pulp
 end
 
 def migrate_foreman
-  Kafo::Helpers.execute('foreman-rake -- config -k use_pulp_oauth -v true')
-  Kafo::Helpers.execute('foreman-rake db:migrate')
-  Kafo::Helpers.execute('foreman-rake -- config -k use_pulp_oauth -v false')
+  Kafo::Helpers.execute(['foreman-rake -- config -k use_pulp_oauth -v true >/dev/null',
+                         'foreman-rake db:migrate',
+                         'foreman-rake -- config -k use_pulp_oauth -v false >/dev/null'])
 end
 
 def remove_nodes_importers


### PR DESCRIPTION
Before this patch, we were ignoring the results of db:migrate rake task in
pre-upgrade hook. While sometimes it helped us with issues, when the second run
of db:migrate inside the installer would finish successfully (just because of
some combination plugins or jumping though multiple versions). We should
however rather be aware of the issues and fixing them, rather than ignoring it,
with potential consequences later.