### PR TITLE
Fixes #18247 - Show initial org in proxy certs gen

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,3 +32,6 @@ Metrics/PerceivedComplexity:
 
 Performance/Casecmp:
   Enabled: false
+
+Style/RescueModifier:
+  Enabled: false

--- a/bin/foreman-proxy-certs-generate
+++ b/bin/foreman-proxy-certs-generate
@@ -20,20 +20,26 @@ class ForemanProxyCertsGenerate
 
   private
 
+  # rubocop: disable Metrics/MethodLength
   def generate_answers_file
+    if File.file?('./config/last_scenario.yaml')
+      scenario = YAML.load_file('./config/last_scenario.yaml').fetch(:answer_file)
+      organization = YAML.load_file("#{scenario}")['foreman']['initial_organization'] rescue "Default Organization"
+    else
+      organization = "Default Organization"
+    end
     temp_file('foreman-proxy-certs-answer',
               <<-EOF
                 certs:
                   generate: true
                   deploy: false
                   group: foreman
-                  org: Default_Organization
+                  org: #{organization.tr(' ', '_')}
                 foreman_proxy_certs: true
               EOF
              )
   end
 
-  # rubocop: disable Metrics/MethodLength
   def generate_config_file
     temp_file('foreman-proxy-certs-config',
               <<-EOF


### PR DESCRIPTION
Right now the org shown to users is Default_Organization regardless of it being that or what was set during the initial install.

Set my org at install to Katello Test:

[root@centos7 ~]# cat /etc/foreman-installer/scenarios.d/katello-answers.yaml | grep initial_organization
    initial_organization: "Katello Test"

Run of certs generate:

[root@centos7 ~]# foreman-proxy-certs-generate --foreman-proxy-fqdn test.example.com --certs-tar /root/certs.tar
Installing             Done                                               [100%] [.................................................................................................................................]
  Success!

  To finish the installation, follow these steps:

  If you do not have the smartproxy registered to the Katello instance, then please do the following:

  1. yum -y localinstall http://centos7.example.com/pub/katello-ca-consumer-latest.noarch.rpm
  2. subscription-manager register --org "Katello Test"

  Once this is completed run the steps below to start the smartproxy installation:

  1. Ensure that the foreman-installer-katello package is installed on the system.
  2. Copy /root/certs.tar to the system test.example.com
  3. Run the following commands on the Foreman proxy (possibly with the customized
     parameters, see foreman-installer --scenario foreman-proxy-content --help and
     documentation for more info on setting up additional services):

  foreman-installer --scenario foreman-proxy-content\
                    --foreman-proxy-content-parent-fqdn           "centos7.example.com"\
                    --foreman-proxy-register-in-foreman           "true"\
                    --foreman-proxy-foreman-base-url              "https://centos7.example.com"\
                    --foreman-proxy-trusted-hosts                 "centos7.example.com"\
                    --foreman-proxy-trusted-hosts                 "test.example.com"\
                    --foreman-proxy-oauth-consumer-key            "cLhcHAr6oA4gGAMMeokY9G7ar39caDUG"\
                    --foreman-proxy-oauth-consumer-secret         "R7e9rBjGXup7xLbctbhBF3mDseFwMgxZ"\
                    --foreman-proxy-content-pulp-oauth-secret     "vtfgkRPWvhGfoApSjqE6NwatQVF2LTis"\
                    --foreman-proxy-content-certs-tar             "/root/certs.tar"
  The full log is at /var/log/foreman-proxy-certs-generate.log