### PR TITLE
fixes #18322 - provide a way to reset certs to self-signed

### DIFF
--- a/hooks/boot/01-helpers.rb
+++ b/hooks/boot/01-helpers.rb
@@ -54,5 +54,9 @@ class Kafo::Helpers
         $?.success?
       end
     end
+
+    def reset_value(param)
+      param.value = nil unless param.nil?
+    end
   end
 end

--- a/hooks/boot/20-certs_update.rb
+++ b/hooks/boot/20-certs_update.rb
@@ -18,6 +18,15 @@ app_option(
   :default => false
 )
 app_option(
+  '--certs-reset',
+  :flag,
+  "This option will reset any custom certificates and use the self-signed CA " \
+  "instead. Note that any clients will need to be updated with the latest " \
+  "katello-ca-consumer RPM, and any external proxies will need to have the " \
+  "certs updated by generating a new certs tarball.",
+  :default => false
+)
+app_option(
   '--certs-skip-check',
   :flag,
   "This option will cause skipping the certificates sanity check. Use with caution",

--- a/hooks/pre/20-certs_update.rb
+++ b/hooks/pre/20-certs_update.rb
@@ -39,7 +39,7 @@ if app_value('certs_update_server')
   mark_for_update("#{hostname}-foreman-proxy", hostname)
 end
 
-if app_value('certs_update_all') || app_value('certs_update_default_ca')
+if app_value('certs_update_all') || app_value('certs_update_default_ca') || app_value('certs_reset')
   all_cert_names = Dir.glob(File.join(SSL_BUILD_DIR, hostname, '*.noarch.rpm')).map do |rpm|
     File.basename(rpm).sub(/-1\.0-\d+\.noarch\.rpm/, '')
   end.uniq
@@ -49,7 +49,7 @@ if app_value('certs_update_all') || app_value('certs_update_default_ca')
   end
 end
 
-if app_value('certs_update_server_ca')
+if app_value('certs_update_server_ca') || app_value('certs_reset')
   mark_for_update('katello-server-ca')
 end
 
@@ -61,4 +61,11 @@ if !app_value('certs_skip_check') &&
   unless $?.success?
     error "Command '#{check_cmd}' exited with #{$?.exitstatus}:\n #{output}"
   end
+end
+
+if app_value('certs_reset') && !app_value(:noop)
+  Kafo::Helpers.reset_value(param('certs', 'server_cert'))
+  Kafo::Helpers.reset_value(param('certs', 'server_key'))
+  Kafo::Helpers.reset_value(param('certs', 'server_cert_req'))
+  Kafo::Helpers.reset_value(param('certs', 'server_ca_cert'))
 end

--- a/hooks/pre/31-upgrade-puppet.rb
+++ b/hooks/pre/31-upgrade-puppet.rb
@@ -38,12 +38,6 @@ def fail_and_exit(message)
   kafo.class.exit 1
 end
 
-def reset_value(param)
-  unless app_value(:noop)
-    param.value = nil unless param.nil?
-  end
-end
-
 if app_value(:upgrade_puppet)
   katello = Kafo::Helpers.module_enabled?(@kafo, 'katello')
   foreman_proxy_content = @kafo.param('foreman_proxy_plugin_pulp', 'pulpnode_enabled').value
@@ -53,15 +47,17 @@ if app_value(:upgrade_puppet)
   Kafo::Helpers.log_and_say :info, 'Upgrading puppet...'
   fail_and_exit 'Unable to find Puppet 4 packages, is the repository enabled?' unless puppet4_available?
 
-  reset_value(param('foreman', 'puppet_home'))
-  reset_value(param('foreman', 'puppet_ssldir'))
-  reset_value(param('foreman_proxy', 'puppet_ssl_ca'))
-  reset_value(param('foreman_proxy', 'puppet_ssl_cert'))
-  reset_value(param('foreman_proxy', 'puppet_ssl_key'))
-  reset_value(param('foreman_proxy', 'puppetdir'))
-  reset_value(param('foreman_proxy', 'ssldir'))
-  reset_value(param('foreman_proxy', 'puppetca_cmd'))
-  reset_value(param('foreman_proxy', 'puppetrun_cmd'))
+  if !app_value(:noop)
+    Katello::Helpers.reset_value(param('foreman', 'puppet_home'))
+    Katello::Helpers.reset_value(param('foreman', 'puppet_ssldir'))
+    Katello::Helpers.reset_value(param('foreman_proxy', 'puppet_ssl_ca'))
+    Katello::Helpers.reset_value(param('foreman_proxy', 'puppet_ssl_cert'))
+    Katello::Helpers.reset_value(param('foreman_proxy', 'puppet_ssl_key'))
+    Katello::Helpers.reset_value(param('foreman_proxy', 'puppetdir'))
+    Katello::Helpers.reset_value(param('foreman_proxy', 'ssldir'))
+    Katello::Helpers.reset_value(param('foreman_proxy', 'puppetca_cmd'))
+    Katello::Helpers.reset_value(param('foreman_proxy', 'puppetrun_cmd'))
+  end
 
   upgrade_step :upgrade_puppet_package
   upgrade_step :stop_services


### PR DESCRIPTION
This PR adds an option called "--certs-reset" that will remove
any settings related to custom certs and then cause a new
self-signed CA to be created.