### PR TITLE
fixes #18402 - only delete pulp.conf explicitly on a proxy

### DIFF
--- a/hooks/pre/29-remove_package_httpd_conf.rb
+++ b/hooks/pre/29-remove_package_httpd_conf.rb
@@ -6,7 +6,7 @@
 # * pulp places a pulp.conf that contains a duplicate WSGI 'pulp'
 #   daemon that 05-pulps-https.conf contains.
 #
-if !Kafo::Helpers.module_enabled?(@kafo, 'katello') && !app_value(:noop)
+if Kafo::Helpers.module_enabled?(@kafo, 'foreman_proxy_content') && !app_value(:noop)
   %w(pulp.conf).each do |file|
     File.delete(File.join("/etc/httpd/conf.d/", file)) if File.file?(File.join("/etc/httpd/conf.d/", file))
   end


### PR DESCRIPTION
!katello is not the same as a proxy with content, as the hooks
also get run by foreman-proxy-certs-generate.  This causes the pulp.conf to get deleted on a Katello when generating proxy certs.
