### PR TITLE
fixes #18405 - modify upgrade to include rake tasks to fix mismatches

### DIFF
--- a/hooks/boot/30-upgrade.rb
+++ b/hooks/boot/30-upgrade.rb
@@ -4,3 +4,9 @@ app_option(
   "Run the steps necessary for an upgrade such as migrations, rake tasks, etc.",
   :default => false
 )
+app_option(
+  '--disable-resolve-mismatches',
+  :flag,
+  "This will disable the resolving of mismatches between the application and backend services, during upgrade.  The steps will still run in a non-commit mode to show what would have been changed.",
+  :default => false
+)

--- a/hooks/post/30-upgrade.rb
+++ b/hooks/post/30-upgrade.rb
@@ -10,6 +10,30 @@ def db_seed
   Kafo::Helpers.execute('foreman-rake db:seed')
 end
 
+def correct_repositories
+  if app_value(:disable_resolve_mismatches)
+    Kafo::Helpers.execute('foreman-rake katello:correct_repositories')
+  else
+    Kafo::Helpers.execute('foreman-rake katello:correct_repositories COMMIT=true')
+  end
+end
+
+def correct_puppet_environments
+  if app_value(:disable_resolve_mismatches)
+    Kafo::Helpers.execute('foreman-rake katello:correct_puppet_environments')
+  else
+    Kafo::Helpers.execute('foreman-rake katello:correct_puppet_environments COMMIT=true')
+  end
+end
+
+def clean_backend_objects
+  if app_value(:disable_resolve_mismatches)
+    Kafo::Helpers.execute('foreman-rake katello:clean_backend_objects')
+  else
+    Kafo::Helpers.execute('foreman-rake katello:clean_backend_objects COMMIT=true')
+  end
+end
+
 def import_package_groups
   Kafo::Helpers.execute('foreman-rake katello:upgrades:2.4:import_package_groups')
 end
@@ -124,6 +148,11 @@ if app_value(:upgrade)
 
     if Kafo::Helpers.module_enabled?(@kafo, 'katello')
       upgrade_step :db_seed, :run_always => true
+
+      upgrade_step :correct_repositories, :long_running => true, :run_always => true
+      upgrade_step :correct_puppet_environments, :long_running => true, :run_always => true
+      upgrade_step :clean_backend_objects, :long_running => true, :run_always => true
+
       upgrade_step :import_package_groups, :long_running => true
       upgrade_step :import_rpms, :long_running => true
       upgrade_step :import_distributions, :long_running => true


### PR DESCRIPTION
There exist several rake tasks in katello to resolve data integrity
issues (or mismatches) between it and the backend services
(pulp and candlepin).  This commit adds those steps to the installer
upgrade process so that the issues can be addressed automatically
versus the current behavior which may result in a failed upgrade
and then a need to run them manually.

Note: this is primarily for differences related to repository
and consumer resources.

The commit also includes an option  (--disable-resolve-mismatches)
to run the upgrade without making any changes.  It will still
run the tasks and report the changes that it would have made.