### PR TITLE
Fixes #18548 - Fix broken copy on Puppet 4 upgrade

### DIFF
--- a/hooks/pre/31-upgrade-puppet.rb
+++ b/hooks/pre/31-upgrade-puppet.rb
@@ -25,9 +25,9 @@ end
 
 def copy_data
   success = []
-  success << Kafo::Helpers.execute('cp -rfp /etc/puppet/environments/* /etc/puppetlabs/code/environments') if File.directory?('/etc/puppet/environments')
-  success << Kafo::Helpers.execute('mv /var/lib/puppet/ssl /etc/puppetlabs/puppet && ln -s /etc/puppetlabs/puppet/ssl /var/lib/puppet/ssl') if File.directory?('/var/lib/puppet/ssl')
-  success << Kafo::Helpers.execute('mv /var/lib/puppet/foreman_cache_data /opt/puppetlabs/puppet/cache/') if File.directory?('/var/lib/puppet/foreman_cache_data')
+  success << Kafo::Helpers.execute('cp -rfp /etc/puppet/environments /etc/puppetlabs/code/environments') if File.directory?('/etc/puppet/environments')
+  success << Kafo::Helpers.execute('cp -rfp /var/lib/puppet/ssl /etc/puppetlabs/puppet') if File.directory?('/var/lib/puppet/ssl')
+  success << Kafo::Helpers.execute('cp -rfp /var/lib/puppet/foreman_cache_data /opt/puppetlabs/puppet/cache/') if File.directory?('/var/lib/puppet/foreman_cache_data')
   !success.include?(false)
 end
 


### PR DESCRIPTION
To test, spin up 3.3 box:

```
ansible-playbook pipelines/pipeline_katello_33.yml -e "forklift_state=up puppet_repositories_version=3"
```

SSH on to the box and run:

```
sudo rpm -Uvh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
foreman-installer --disable-system-checks --upgrade-puppet
```

After you see it fail, copy patched file to `/usr/share/katello-intaller-base/hooks/pre` and re-run upgrade.