### PR TITLE
fixes #18797 - Not to use relative path with certs-tar option

### DIFF
--- a/hooks/post/10-post_install.rb
+++ b/hooks/post/10-post_install.rb
@@ -28,7 +28,7 @@ if [0, 2].include?(@kafo.exit_code)
       say <<MSG
   * To install an additional Foreman proxy on separate machine continue by running:
 
-      foreman-proxy-certs-generate --foreman-proxy-fqdn "<%= color('$FOREMAN_PROXY', :info) %>" --certs-tar "<%= color('~/$FOREMAN_PROXY-certs.tar', :info) %>"
+      foreman-proxy-certs-generate --foreman-proxy-fqdn "<%= color('$FOREMAN_PROXY', :info) %>" --certs-tar "<%= color('/root/$FOREMAN_PROXY-certs.tar', :info) %>"
 
 MSG
     end


### PR DESCRIPTION
The hooks/post/10-post_install.rb file uses relative path with certs-tar option.
but I can not be used with. cause the certs-tar option requires absolute path.
The error was:

```
[root@katello01 ~]# foreman-proxy-certs-generate --foreman-proxy-fqdn "$FOREMAN_PROXY" --certs-tar "~/$FOREMAN_PROXY-certs.tar"
Parameter certs-tar invalid: ~/puppetca01.example.net-certs.tar is not one of regexes matching /^(([a-zA-Z]:[\\\/])|([\\\/][\\\/][^\\\/]+[\\\/][^\\\/]+)|([\\\/][\\\/]\?[\\\/][^\\\/]+))/ or regexes matching /^\/([^\/\0]+(\/)?)+$/
Error during configuration, exiting
```
