### PR TITLE
Fixes #18849: katello-certs-check does not check expiration date

### DIFF
--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -53,6 +53,27 @@ function success () {
     echo "[OK]"
 }
 
+function check-expiration () {
+  DATE=$(date -u +"%b %-d %R:%S %Y")
+  CERT_EXP=$(openssl x509 -noout -enddate -in $CERT_FILE | sed -e 's/notAfter=//' | awk '{$NF="";}1')
+  CA_EXP=$(openssl x509 -noout -enddate -in $CA_BUNDLE_FILE | sed -e 's/notAfter=//' | awk '{$NF="";}1')
+  DATE_TODAY=`date -d"${DATE}" +%Y%m%d%H%M%S`
+  CERT_DATE=`date -d"${CERT_EXP}" +%Y%m%d%H%M%S`
+  CA_DATE=`date -d"${CA_EXP}" +%Y%m%d%H%M%S`
+  printf "Checking expiration of certificate: "
+  if [ $DATE_TODAY -gt $CERT_DATE ]; then
+    error 6 "The certificate \"$CERT_FILE\" already expired on: $CERT_EXP"
+  else
+    success
+  fi
+  printf "Checking expiration of CA bundle: "
+  if [ $DATE_TODAY -gt $CA_DATE ]; then
+    error 7 "The CA bundle \"$CA_BUNDLE_FILE\" already expired on: $CA_EXP"
+  else
+    success
+  fi
+}
+
 function show-details () {
     printf "Validating the certificate "
     CERT_SUBJECT=$(openssl x509 -noout -subject -in $CERT_FILE)
@@ -81,6 +102,7 @@ function check-ca-bundle () {
     fi
 }
 
+check-expiration
 show-details
 check-priv-key
 check-ca-bundle

--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -54,24 +54,24 @@ function success () {
 }
 
 function check-expiration () {
-  DATE=$(date -u +"%b %-d %R:%S %Y")
-  CERT_EXP=$(openssl x509 -noout -enddate -in $CERT_FILE | sed -e 's/notAfter=//' | awk '{$NF="";}1')
-  CA_EXP=$(openssl x509 -noout -enddate -in $CA_BUNDLE_FILE | sed -e 's/notAfter=//' | awk '{$NF="";}1')
-  DATE_TODAY=`date -d"${DATE}" +%Y%m%d%H%M%S`
-  CERT_DATE=`date -d"${CERT_EXP}" +%Y%m%d%H%M%S`
-  CA_DATE=`date -d"${CA_EXP}" +%Y%m%d%H%M%S`
-  printf "Checking expiration of certificate: "
-  if [ $DATE_TODAY -gt $CERT_DATE ]; then
-    error 6 "The certificate \"$CERT_FILE\" already expired on: $CERT_EXP"
-  else
-    success
-  fi
-  printf "Checking expiration of CA bundle: "
-  if [ $DATE_TODAY -gt $CA_DATE ]; then
-    error 7 "The CA bundle \"$CA_BUNDLE_FILE\" already expired on: $CA_EXP"
-  else
-    success
-  fi
+    DATE=$(date -u +"%b %-d %R:%S %Y")
+    CERT_EXP=$(openssl x509 -noout -enddate -in $CERT_FILE | sed -e 's/notAfter=//' | awk '{$NF="";}1')
+    CA_EXP=$(openssl x509 -noout -enddate -in $CA_BUNDLE_FILE | sed -e 's/notAfter=//' | awk '{$NF="";}1')
+    DATE_TODAY=`date -d"${DATE}" +%Y%m%d%H%M%S`
+    CERT_DATE=`date -d"${CERT_EXP}" +%Y%m%d%H%M%S`
+    CA_DATE=`date -d"${CA_EXP}" +%Y%m%d%H%M%S`
+    printf "Checking expiration of certificate: "
+    if [ $DATE_TODAY -gt $CERT_DATE ]; then
+        error 6 "The certificate \"$CERT_FILE\" already expired on: $CERT_EXP"
+    else
+        success
+    fi
+    printf "Checking expiration of CA bundle: "
+    if [ $DATE_TODAY -gt $CA_DATE ]; then
+        error 7 "The CA bundle \"$CA_BUNDLE_FILE\" already expired on: $CA_EXP"
+    else
+        success
+    fi
 }
 
 function show-details () {


### PR DESCRIPTION
Added checks for the expiration date of the CA and the Certificate individually.
Had them checked separately as they can be created/developed separately in user environments.