### PR TITLE
Fixes #19180 - Remove crane

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -4,7 +4,6 @@ mod 'katello/candlepin',             :git => 'https://github.com/Katello/puppet-
 mod 'katello/foreman_proxy_content', :git => 'https://github.com/Katello/puppet-foreman_proxy_content'
 mod 'katello/certs',                 :git => 'https://github.com/Katello/puppet-certs'
 mod 'katello/common',                :git => 'https://github.com/Katello/puppet-common'
-mod 'katello/crane',                 :git => 'https://github.com/Katello/puppet-crane'
 mod 'katello/katello',               :git => 'https://github.com/Katello/puppet-katello'
 mod 'katello/pulp',                  :git => 'https://github.com/Katello/puppet-pulp'
 mod 'katello/qpid',                  :git => 'https://github.com/Katello/puppet-qpid'


### PR DESCRIPTION
The crane module is deprecated and now part of katello/pulp as pulp::crane.

I believe no migration is needed since it wasn't exposed directly to users.