### PR TITLE
Fixes #19118 - Configure CLI on server

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -146,6 +146,7 @@ namespace :config do
   end
 end
 
-CLEAN.include(BUILDDIR, PKGDIR)
+CLEAN.include(BUILDDIR)
+CLEAN.include(PKGDIR)
 
 task :default => [:rubocop, :spec, 'pkg:generate_source']

--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -79,3 +79,4 @@ foreman::compute::openstack: false
 foreman::compute::ovirt: false
 foreman::compute::rackspace: false
 foreman::compute::vmware: false
+foreman::cli: true

--- a/config/katello.migrations/170331152302-add-cli.rb
+++ b/config/katello.migrations/170331152302-add-cli.rb
@@ -1,0 +1,1 @@
+answers['foreman::cli'] ||= true

--- a/hooks/pre_migrations/01-migrate_legacy_foreman_installer_config.rb
+++ b/hooks/pre_migrations/01-migrate_legacy_foreman_installer_config.rb
@@ -13,7 +13,7 @@ if File.exists?(legacy_config_file)
     scenario = Kafo::Configuration.new(scenario_file)
 
     # copy over config and answers
-    scenario.migrate_configuration(legacy_config, :skip => [:log_dir, :log_name])
+    scenario.migrate_configuration(legacy_config, :skip => %i(log_dir log_name))
     scenario.store(legacy_config.answers)
 
     # link last used scenario

--- a/hooks/pre_migrations/10-migrate_legacy_capsule_config.rb
+++ b/hooks/pre_migrations/10-migrate_legacy_capsule_config.rb
@@ -13,7 +13,7 @@ if File.exists?(legacy_config_file)
     scenario = Kafo::Configuration.new(scenario_file)
 
     # copy over config and answers
-    scenario.migrate_configuration(legacy_config, :skip => [:log_dir, :log_name])
+    scenario.migrate_configuration(legacy_config, :skip => %i(log_dir log_name))
     scenario.store(legacy_config.answers)
 
     # link last used scenario

--- a/hooks/pre_migrations/11-migrate_legacy_katello_config.rb
+++ b/hooks/pre_migrations/11-migrate_legacy_katello_config.rb
@@ -13,7 +13,7 @@ if File.exists?(legacy_config_file)
     scenario = Kafo::Configuration.new(scenario_file)
 
     # copy over config and answers
-    scenario.migrate_configuration(legacy_config, :skip => [:log_dir, :log_name])
+    scenario.migrate_configuration(legacy_config, :skip => %i(log_dir log_name))
     scenario.store(legacy_config.answers)
 
     # link last used scenario


### PR DESCRIPTION
The recent change to hammer to verify SSL means we need to configure SSL and the hostname of the hammer config needs to match. The base configuration deploys at `https://localhost' and the `foreman::cli` manifest configure both the SSL certificate and sets the hostname properly. 

This would fix current bats failures -- http://ci.theforeman.org/view/Katello%20Pipeline/job/release_test_katello_nightly_el7/291/console