### PR TITLE
Fixes #20032 - Ensure service-wait is always executable

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -41,6 +41,10 @@ file "#{BUILDDIR}/modules" do |t|
     mkdir BUILDDIR
     cp_r "modules", "#{BUILDDIR}/modules"
   end
+
+  # Ensure service-wait is executable since depending on the version of puppet
+  # it can get installed without being executable
+  FileUtils.chmod(0775, "#{BUILDDIR}/modules/service_wait/bin/service-wait")
 end
 
 task :generate_parser_caches => [PARSER_CACHE_DIR] do


### PR DESCRIPTION
At some point, a newer version of puppet in the 4.X line, puppet started installing puppet modules without the permissions they were uploaded to puppetforge. In our case, this can mean service-wait ends up not executable, and thus is not executed with the custom provider. The present outcome is that at times the proxy can start slow and registration will fail if this is not present. This is not a pretty solution but it solves the immediate breakages that can occur such as what is afflicting latest 3.4.1.2 installer package.