### PR TITLE
Fixes #20056 - deletes queue when its not created with hostname

### DIFF
--- a/hooks/post/30-upgrade.rb
+++ b/hooks/post/30-upgrade.rb
@@ -101,9 +101,9 @@ def remove_gutterball
 end
 
 def remove_event_queue
-  queue_present = `qpid-stat -q --ssl-certificate=/etc/pki/katello/qpid_client_striped.crt -b amqps://localhost:5671 | grep :event | wc -l`.chomp.to_i
-  if queue_present > 0
-    Kafo::Helpers.execute('qpid-config --ssl-certificate=/etc/pki/katello/qpid_client_striped.crt -b amqps://localhost:5671 del queue $(hostname -f):event --force > /dev/null 2>&1')
+  queue_present = `qpid-stat -q --ssl-certificate=/etc/pki/katello/qpid_client_striped.crt -b amqps://localhost:5671 | grep :event`.split(" ").first
+  if queue_present
+    Kafo::Helpers.execute("qpid-config --ssl-certificate=/etc/pki/katello/qpid_client_striped.crt -b amqps://localhost:5671 del queue #{queue_present} --force > /dev/null 2>&1")
   else
     logger.info 'Event queue is already removed, skipping'
   end


### PR DESCRIPTION
Deletes queue when :event queue was not created by system's hostname.