### PR TITLE
fixes #20054 - Add test if server X.509 cert is in PEM encoding

### DIFF
--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -112,6 +112,29 @@ function check-ca-bundle () {
     fi
 }
 
+function check-server-cert-encoding () {
+    printf "Checking server certificate's encoding: "
+    openssl x509 -inform pem -in $CERT_FILE -noout -text &> /dev/null
+    if [ $? == "0" ]; then
+        success
+    else
+        openssl x509 -inform der -in $CERT_FILE -noout -text &> /dev/null
+        if [ $? == "0" ]; then
+            printf "[FAIL]\n"
+            printf "The server certificate is in DER encoding, which is incompatible.\n\n"
+            printf "Run the following command to convert the certificate to PEM encoding,\n"
+            printf "then test it again.\n"
+            printf "# openssl x509 -in %s -outform pem -out %s.pem\n\n" $(basename $CERT_FILE) $(basename $CERT_FILE)
+            printf "When you run $(basename $0) again, use file\n"
+            printf "%s.pem for the server certificate.\n" $(basename $CERT_FILE)
+            exit 8
+        else
+            error 9 "The encoding of the server certificate is unknown."
+        fi
+    fi
+}
+
+check-server-cert-encoding
 check-expiration
 check-cert-ca-flag
 show-details


### PR DESCRIPTION
Added a function to test if the server X.509 certificate provided is
in PEM encoding. If not, a notification message is output, also the
necessary `openssl` command to convert the certificate from DER
encoding to PEM encoding.