### PR TITLE
Fixes #20593 - Prevent puppet upgrade on fresh install

### DIFF
--- a/hooks/boot/01-helpers.rb
+++ b/hooks/boot/01-helpers.rb
@@ -10,7 +10,7 @@ class Kafo::Helpers
       mod.enabled?
     end
 
-    def log_and_say(level, message)
+    def log_and_say(level, message, do_say = true)
       style = case level
               when :error
                 'bad'
@@ -22,7 +22,7 @@ class Kafo::Helpers
 
       # \ and ' characters could cause trouble in ERB, make sure to escape them
       escaped_message = message.gsub('\\', '\\\\\\').gsub("'", %q{\\\'})
-      say "<%= color('#{escaped_message}', :#{style}) %>"
+      say "<%= color('#{escaped_message}', :#{style}) %>" if do_say
       Kafo::KafoConfigure.logger.send(level, message)
     end
 
@@ -30,26 +30,26 @@ class Kafo::Helpers
       YAML.load_file("#{puppet_dir}/foreman_cache_data/#{param}")
     end
 
-    def execute(commands)
+    def execute(commands, do_say = true)
       commands = commands.is_a?(Array) ? commands : [commands]
       results = []
       commands.each do |command|
-        results << execute_command(command)
+        results << execute_command(command, do_say)
       end
       !results.include? false
     end
 
-    def execute_command(command)
+    def execute_command(command, do_say)
       process = IO.popen("#{command} 2>&1") do |io|
         while line = io.gets
           line.chomp!
-          log_and_say(:debug, line)
+          log_and_say(:debug, line, do_say)
         end
         io.close
         if $?.success?
-          log_and_say(:debug, "#{command} finished successfully!")
+          log_and_say(:debug, "#{command} finished successfully!", do_say)
         else
-          log_and_say(:error, "#{command} failed! Check the output for error!")
+          log_and_say(:error, "#{command} failed! Check the output for error!", do_say)
         end
         $?.success?
       end

--- a/hooks/pre/31-upgrade-puppet.rb
+++ b/hooks/pre/31-upgrade-puppet.rb
@@ -50,6 +50,7 @@ if app_value(:upgrade_puppet)
   PUPPET_UPGRADE_COMPLETE = '/etc/foreman-installer/.puppet_4_upgrade'.freeze
 
   fail_and_exit 'Puppet already installed and upgraded. Skipping.' if File.exist?(PUPPET_UPGRADE_COMPLETE)
+
   katello = Kafo::Helpers.module_enabled?(@kafo, 'katello')
   foreman_proxy_content = @kafo.param('foreman_proxy_plugin_pulp', 'pulpnode_enabled').value
 
@@ -100,6 +101,5 @@ if app_value(:upgrade_puppet)
   upgrade_step :remove_puppet_port_httpd
   upgrade_step :start_httpd
 
-  File.open(PUPPET_UPGRADE_COMPLETE, 'w') { |file| file.write("Puppet 3 to 4 upgrade completed on #{Time.now}") }
   Kafo::Helpers.log_and_say :info, "Puppet 3 to 4 upgrade initialization complete, continuing with installation"
 end


### PR DESCRIPTION
The idea behind this change:

 1) Only create the upgrade complete file when the post puppet upgrade step finishes
 2) Add a check for puppet 4 installed, no --upgrade-puppet parameter passed, and create the puppet upgrade file

This last point is to try to prevent the case of installing with Pupept 4 and then being able to run --upgrade-puppet. Please check my logic adjustments carefully.