### PR TITLE
Fixes #21222 - Don't log rpm -q output

### DIFF
--- a/hooks/post/31-upgrade-puppet.rb
+++ b/hooks/post/31-upgrade-puppet.rb
@@ -22,8 +22,8 @@ end
 
 def puppet4_installed?
   success = []
-  success << Kafo::Helpers.execute('rpm -q puppet-agent', false)
-  success << Kafo::Helpers.execute('rpm -q puppetserver', false)
+  success << Kafo::Helpers.execute('rpm -q puppet-agent', false, false)
+  success << Kafo::Helpers.execute('rpm -q puppetserver', false, false)
   !success.include?(false)
 end
 


### PR DESCRIPTION
When running rpm -q we only care about the result, not to log
the result of the execution. This could lead to ERROR output
when no real error is occurring.