### PR TITLE
Refs #21060 - fix proxy success message to have the right url

### DIFF
--- a/hooks/boot/02-message-helpers.rb
+++ b/hooks/boot/02-message-helpers.rb
@@ -19,7 +19,8 @@ MSG
 
     def proxy_success_message(kafo)
       success_message
-      say "  * <%= color('Foreman Proxy', :info) %> is running at <%= color('#{kafo.param('foreman_proxy', 'registered_proxy_url').value}:#{kafo.param('foreman_proxy', 'ssl_port')}', :info) %>"
+      foreman_proxy_url = kafo.param('foreman_proxy', 'registered_proxy_url').value || "https://#{kafo.param('foreman_proxy', 'registered_name').value}:#{kafo.param('foreman_proxy', 'ssl_port').value}"
+      say "  * <%= color('Foreman Proxy', :info) %> is running at <%= color('#{foreman_proxy_url}', :info) %>"
     end
 
     def new_install_message(kafo)


### PR DESCRIPTION
before:

    * Foreman Proxy is running at :#<Kafo::Param:20255140 @name="ssl_port" @default=8443 @value=9090 @type=integer (between 0 and 65535)>

after:

    * Foreman Proxy is running at https://fp.example.com:8443