### PR TITLE
Fixes #21268 - only migrate qpid directories, not random files

### DIFF
--- a/hooks/pre/30-upgrade.rb
+++ b/hooks/pre/30-upgrade.rb
@@ -147,6 +147,7 @@ def upgrade_qpid_paths
     # Move qpid jrnl files
     Dir.foreach("#{qpid_linearstore}/jrnl") do |queue_name|
       next if queue_name == '.' || queue_name == '..'
+      next unless File.directory?("#{qpid_linearstore}/jrnl/#{queue_name}")
 
       puts "Moving #{queue_name}"
       Kafo::Helpers.execute("mkdir -p #{qpid_linearstore}/jrnl2/#{queue_name}/")


### PR DESCRIPTION
people sometimes place files at random places and then wonder why
things blow up, let's be nice to people