### PR TITLE
Refs #20550 - Reset remote database

### DIFF
--- a/hooks/boot/01-helpers.rb
+++ b/hooks/boot/01-helpers.rb
@@ -60,3 +60,14 @@ class Kafo::Helpers
     end
   end
 end
+
+# FIXME: remove when #23332 is released
+module HookContextExtension
+  def param_value(mod, name)
+    param(mod, name).value if param(mod, name)
+  end
+end
+
+unless Kafo::HookContext.method_defined?(:param_value)
+  Kafo::HookContext.send(:include, HookContextExtension)
+end

--- a/hooks/pre_commit/05-puppet_certs_exist.rb
+++ b/hooks/pre_commit/05-puppet_certs_exist.rb
@@ -4,10 +4,6 @@ def error(message)
   kafo.class.exit 101
 end
 
-def param_value(mod, name)
-  param(mod, name).value if param(mod, name)
-end
-
 puppet_ca_enabled = param_value('foreman_proxy', 'puppetca')
 server_crl_path = param_value('foreman', 'server_ssl_crl')
 cert_dir = param_value('foreman_proxy', 'ssldir')


### PR DESCRIPTION
We usually don't have permissions to drop remote DBs. This fix lets installer to drop only tables and keep the empty DB during `--reset`. The original behavior (drop whole DB) is preserved for local databases.

https://github.com/Katello/katello-packaging/pull/499 is required for it to work