### PR TITLE
Fixes #21345 - Allow unicode in certs

### DIFF
--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -112,24 +112,11 @@ function check-ca-bundle () {
     fi
 }
 
-function check-non-ascii () {
-    printf "Checking for non ascii characters"
-    CHECK=$(grep --color='auto' -P -n "[\x80-\xFF]" $CA_BUNDLE_FILE $CERT_FILE)
-    if [ $? == "1" ]; then
-	 success
-    else
-        error 4 "There are non ascii characters present:"
-        echo
-        echo $CHECK
-    fi
-}
-
 check-expiration
 check-cert-ca-flag
 show-details
 check-priv-key
 check-ca-bundle
-check-non-ascii
 
 if [ $EXIT_CODE == "0" ]; then
     cat <<EOF


### PR DESCRIPTION
This is a reversion of 4cdf033184cf43cbb662b3ae5a0329dbe2baf442 except for the grammar changes.