### PR TITLE
Pin rubocop to 0.50

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 group :test do
   gem 'rspec'
-  gem 'rubocop'
+  gem 'rubocop', '~> 0.50.0'
 end
 
 gem 'kafo', '>= 1.0.5'


### PR DESCRIPTION
We use Ruby 2.0 style and 0.50 is the last to support that.