### PR TITLE
Fixes #21936 - Import product content for 3.6

### DIFF
--- a/hooks/post/30-upgrade.rb
+++ b/hooks/post/30-upgrade.rb
@@ -46,6 +46,10 @@ def import_distributions
   Kafo::Helpers.execute('foreman-rake katello:upgrades:2.4:import_distributions')
 end
 
+def import_product_content
+  Kafo::Helpers.execute('foreman-rake katello:upgrades:3.6:import_product_content')
+end
+
 def import_puppet_modules
   Kafo::Helpers.execute('foreman-rake katello:upgrades:2.4:import_puppet_modules')
 end
@@ -166,6 +170,7 @@ if app_value(:upgrade)
       upgrade_step :import_distributions, :long_running => true
       upgrade_step :import_puppet_modules, :long_running => true
       upgrade_step :import_subscriptions, :long_running => true
+      upgrade_step :import_product_content, :long_running => true
       upgrade_step :elasticsearch_message
       upgrade_step :add_export_distributor, :long_running => true
       upgrade_step :remove_docker_v1_content, :long_running => true


### PR DESCRIPTION
Initial content import must be performed upon migrating to 3.6 due to [this change](https://github.com/Katello/katello/commit/946b2990c9a054babc9ad563e1b14c4161207b3e).

Since nightly build is broken, this can be tested on the centos7-katello-bats-ci box which has the above code. The changes here are easily applied manually.

There's an issue with pulp which causes the installer to fail at the clean_backend_objects step. Perform the workaround below before running the installer.

> yum install python-django
systemctl restart httpd pulp_workers pulp_resource_manager pulp_celerybeat pulp_streamer

The import_product_content step will likely run fast because you don't have any content to be imported. I don't think there's a need to test the rake task though, since it has been tested previously.


long_running flag is present because this can take ~1 minute for lots of products. and run_always because  ... why not? :)
