### PR TITLE
fixes #22173 - clear msg when fwd ip doesn't resolve

### DIFF
--- a/checks/dns.rb
+++ b/checks/dns.rb
@@ -24,8 +24,12 @@ forwards.each do |ip|
     error_exit("Forward DNS points to #{ip} which is not configured on this server")
   end
 
-  reverse = Resolv.getname(ip.to_s)
-  unless hostname == reverse
-    error_exit("Reverse DNS #{reverse} does not match hostname #{hostname}")
+  begin
+    reverse = Resolv.getname(ip.to_s)
+    unless hostname == reverse
+      error_exit("Reverse DNS #{reverse} does not match hostname #{hostname}")
+    end
+  rescue Resolv::ResolvError
+    error_exit("Forward DNS #{ip} did not reverse resolve to any hostname.")
   end
 end


### PR DESCRIPTION
When an IP address is included in the forward resolution, but has no
reverse record at all, we throw an exception instead of showing an
error message.

Before:
```
/usr/share/ruby/resolv.rb:130:in `getname': no name for 192.168.1.6
(Resolv::ResolvError) from /usr/share/ruby/resolv.rb:66:in `getname'
        from ./dns.rb:27:in `block in <main>' from ./dns.rb:21:in `each'
        from ./dns.rb:21:in `<main>'
```

After:
```
Forward DNS 192.168.1.6 did not reverse resolve to any hostname.
```