### PR TITLE
refs #22196 - do not configure hammer SSL CA certificate bundle

### DIFF
--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -54,8 +54,6 @@ foreman_proxy:
 foreman_proxy::plugin::pulp:
   enabled: true
   pulpnode_enabled: false
-foreman::cli:
-  ssl_ca_file: /etc/pki/katello/certs/katello-server-ca.crt
 foreman::plugin::ansible: false
 foreman::plugin::bootdisk: false
 foreman::plugin::chef: false
@@ -82,3 +80,4 @@ foreman::compute::openstack: false
 foreman::compute::ovirt: false
 foreman::compute::rackspace: false
 foreman::compute::vmware: false
+foreman::cli: true

--- a/config/katello.migrations/180109093420-hammer-ssl-cert.rb
+++ b/config/katello.migrations/180109093420-hammer-ssl-cert.rb
@@ -1,5 +1,0 @@
-if answers['foreman::cli'].is_a? Hash # If user has already specified options, set the SSL CA file
-  answers['foreman::cli']['ssl_ca_file'] = '/etc/pki/katello/certs/katello-server-ca.crt'
-elsif answers['foreman::cli'] # Otherwise set the SSL CA file only if foreman::cli is still enabled
-  answers['foreman::cli'] = {'ssl_ca_file' => '/etc/pki/katello/certs/katello-server-ca.crt'}
-end


### PR DESCRIPTION
Reverts Katello/katello-installer#574, replaced with https://github.com/theforeman/puppet-foreman/pull/615