### PR TITLE
Refs #21703 - remove registration tasks

### DIFF
--- a/hooks/post/30-upgrade.rb
+++ b/hooks/post/30-upgrade.rb
@@ -54,6 +54,10 @@ def import_puppet_modules
   Kafo::Helpers.execute('foreman-rake katello:upgrades:2.4:import_puppet_modules')
 end
 
+def remove_registration_tasks
+  Kafo::Helpers.execute('foreman-rake foreman_tasks:cleanup TASK_SEARCH="label = Actions::Katello::Host::Register" STATES=all')
+end
+
 def import_subscriptions
   Kafo::Helpers.execute('foreman-rake katello:import_subscriptions')
 end
@@ -191,6 +195,7 @@ if app_value(:upgrade)
       upgrade_step :create_host_subscription_associations, :long_running => true
       upgrade_step :reindex_docker_tags, :long_running => true
       upgrade_step :republish_file_repos, :long_running => true
+      upgrade_step :remove_registration_tasks
     end
 
     if [0, 2].include? @kafo.exit_code


### PR DESCRIPTION
`Host::Register` tasks have been removed as part of
https://github.com/Katello/katello/pull/7082.

This change adds a step to remove all tasks with label
`Actions::Katello::Host::Register`. Without this, already-executed tasks will
show as blank in the web UI.