### PR TITLE
refs #22173 - handle ipv6 on broken rubies

### DIFF
--- a/checks/dns.rb
+++ b/checks/dns.rb
@@ -30,6 +30,14 @@ forwards.each do |ip|
       error_exit("Reverse DNS #{reverse} does not match hostname #{hostname}")
     end
   rescue Resolv::ResolvError
+    # Because of https://bugs.ruby-lang.org/issues/12112:
+    if ip.ipv6?
+      reverse = Resolv::DNS.open do |dns|
+        dns.getresources ip.ip6_arpa, Resolv::DNS::Resource::IN::PTR
+      end.first
+      next if reverse && hostname == reverse.name.to_s
+    end
+
     error_exit("Forward DNS #{ip} did not reverse resolve to any hostname.")
   end
 end


### PR DESCRIPTION
Ruby < 2.3 doesn't support getname on IPv6 addresses: https://bugs.ruby-lang.org/issues/12112

My first thought was to just skip the test on old ruby:
```
next if ip.ipv6? && Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3.0')
```
@ekohl proposed using getresources, which works in my test environment that has real DNS servers. However, if a user expects /etc/hosts to work for forward/reverse lookups, it won't with getresources.  

Only Resolv::Hosts seems to do that, and that's broken with IPv6.

Thoughts?
