### PR TITLE
Fixes #22703 - Look for /var/lib/puppet first

### DIFF
--- a/hooks/boot/01-helpers.rb
+++ b/hooks/boot/01-helpers.rb
@@ -1,7 +1,7 @@
 class Kafo::Helpers
   class << self
     def puppet_dir
-      @puppet_dir ||= File.directory?('/opt/puppetlabs/puppet') ? '/opt/puppetlabs/puppet/cache' : '/var/lib/puppet'
+      @puppet_dir ||= File.directory?('/var/lib/puppet') ? '/var/lib/puppet' : '/opt/puppetlabs/puppet/cache'
     end
 
     def module_enabled?(kafo, name)


### PR DESCRIPTION
This would first look for /var/lib/puppet directory for candlepin_db_password file instead of going in 
/opt/puppetlabs/puppet/cache/ directory, this ensures if puppetlab's puppet agent has installed then installer should not fail to get file candlepin_db_password.