### PR TITLE
Refs #22558: Add a nil check on foreman auth

### DIFF
--- a/hooks/post/10-post_install.rb
+++ b/hooks/post/10-post_install.rb
@@ -18,7 +18,7 @@ if [0, 2].include?(@kafo.exit_code)
       Kafo::Helpers.certs_generate_command_message
     elsif Kafo::Helpers.module_enabled?(@kafo, 'katello_devel')
       Kafo::Helpers.dev_server_success_message(@kafo)
-      Kafo::Helpers.new_install_message(@kafo) if @kafo.param('foreman', 'authentication').value == true && new_install?
+      Kafo::Helpers.new_install_message(@kafo) if @kafo.param('foreman', 'authentication').try(:value) == true && new_install?
     end
 
     Kafo::Helpers.proxy_instructions_message(@kafo) if Kafo::Helpers.module_enabled?(@kafo, 'foreman_proxy_certs')


### PR DESCRIPTION
@ekohl This is nil for me. I'm not sure if that's an expected case. Related: https://github.com/Katello/katello-installer/pull/589

```
[ INFO 2018-03-01T18:59:59 verbose]  Katello_devel::Bundle[exec rails s -d]: Scheduling refresh of Exec[bundle-exec rails s -d]                                                                                                               
[ WARN 2018-03-01T19:00:14 verbose]  /Stage[main]/Katello_devel::Setup/Katello_devel::Bundle[exec rails s -d]/Exec[bundle-exec rails s -d]/returns: executed successfully                                                                     
[ WARN 2018-03-01T19:00:14 verbose]  /Stage[main]/Katello_devel::Setup/Katello_devel::Bundle[exec rails s -d]/Exec[bundle-exec rails s -d]: Triggered 'refresh' from 1 events                                                                 
[ WARN 2018-03-01T19:00:15 verbose]  /Stage[main]/Katello_devel::Setup/Exec[destroy rails server]/returns: executed successfully                                                                                                              
[ WARN 2018-03-01T19:00:15 verbose]  /Stage[main]/Katello_devel::Setup/Exec[destroy rails server]: Triggered 'refresh' from 1 events                                                                                                          
[ WARN 2018-03-01T19:00:15 verbose]  Applied catalog in 513.60 seconds                                                 
[ INFO 2018-03-01T19:00:17 verbose] Puppet has finished, bye!                                                          
[ INFO 2018-03-01T19:00:17 verbose] Executing hooks in group post                                                      
  Success!                                                 
  * To run the Katello dev server log in using SSH         
  * Run `cd foreman && bundle exec foreman start`          
  * The server is running at https://centos7.akofink-desktop                                                           
                                                           
  * On Firefox you need to accept the certificate at https://centos7.akofink-desktop                                   
:3808                                                                                                                  
[ INFO 2018-03-01T19:00:17 verbose] Installer finished in 525.71697479 seconds                                         
                                                                                                                                                                                                                                              
                                                                                                                       
STDERR:                                                    
                                                                                                                       
/usr/share/katello-installer-base/hooks/post/10-post_install.rb:21:in `block (4 levels) in load': undefined method `value' for nil:NilClass (NoMethodError)                                                                                   
        from /usr/share/gems/gems/kafo-2.1.0/lib/kafo/hooking.rb:34:in `instance_eval'                                                                                                                                                        
        from /usr/share/gems/gems/kafo-2.1.0/lib/kafo/hooking.rb:34:in `block (4 levels) in load'                                                                                                                                             
        from /usr/share/gems/gems/kafo-2.1.0/lib/kafo/hook_context.rb:16:in `instance_exec'                                                                                                                                                   
        from /usr/share/gems/gems/kafo-2.1.0/lib/kafo/hook_context.rb:16:in `execute'                                                                                                                                                         
        from /usr/share/gems/gems/kafo-2.1.0/lib/kafo/hooking.rb:51:in `block in execute'                                                                                                                                                     
        from /usr/share/gems/gems/kafo-2.1.0/lib/kafo/hooking.rb:49:in `each'                                                                                                                                                                 
        from /usr/share/gems/gems/kafo-2.1.0/lib/kafo/hooking.rb:49:in `execute'                                                                                                                                                              
        from /usr/share/gems/gems/kafo-2.1.0/lib/kafo/kafo_configure.rb:476:in `block in run_installation'                                                                                                                                    
        from /usr/share/gems/gems/kafo-2.1.0/lib/kafo/exit_handler.rb:29:in `call'                                                                                                                                                            
        from /usr/share/gems/gems/kafo-2.1.0/lib/kafo/exit_handler.rb:29:in `exit'                                                                                                                                                            
        from /usr/share/gems/gems/kafo-2.1.0/lib/kafo/kafo_configure.rb:169:in `exit'                                                                                                                                                         
        from /usr/share/gems/gems/kafo-2.1.0/lib/kafo/kafo_configure.rb:475:in `run_installation'                                                                                                                                             
        from /usr/share/gems/gems/kafo-2.1.0/lib/kafo/kafo_configure.rb:156:in `execute'                                                                                                                                                      
        from /usr/share/gems/gems/clamp-1.1.2/lib/clamp/command.rb:63:in `run'                                                                                                                                                                
        from /usr/share/gems/gems/kafo-2.1.0/lib/kafo/kafo_configure.rb:119:in `run'                                                                                                                                                          
        from /usr/share/gems/gems/clamp-1.1.2/lib/clamp/command.rb:132:in `run'                                                                                                                                                               
        from /usr/share/gems/gems/kafo-2.1.0/lib/kafo/kafo_configure.rb:163:in `run'                                                                                                                                                          
        from /sbin/foreman-installer:8:in `<main>'                                                                                                                                                                                            
                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                              
MSG:                                                       
                                                           
non-zero return code                                                                                                                                                                                                                          

        to retry, use: --limit @/home/akofink/.ansible/retry-files/devel.retry

PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
centos7                    : ok=21   changed=9    unreachable=0    failed=1
```