### PR TITLE
Refs #22558: Handle the devel credentials

### DIFF
--- a/hooks/boot/02-message-helpers.rb
+++ b/hooks/boot/02-message-helpers.rb
@@ -37,6 +37,10 @@ MSG
       say "      Initial credentials are <%= color('#{kafo.param('foreman', 'admin_username').value}', :info) %> / <%= color('#{kafo.param('foreman', 'admin_password').value}', :info) %>"
     end
 
+    def dev_new_install_message(kafo)
+      say "      Initial credentials are <%= color('admin', :info) %> / <%= color('#{kafo.param('katello_devel', 'admin_password').value}', :info) %>"
+    end
+
     def proxy_instructions_message(kafo)
       fqdn = if kafo.param('foreman_proxy_certs', 'parent_fqdn')
                kafo.param('foreman_proxy_certs', 'parent_fqdn').value

--- a/hooks/post/10-post_install.rb
+++ b/hooks/post/10-post_install.rb
@@ -18,7 +18,7 @@ if [0, 2].include?(@kafo.exit_code)
       Kafo::Helpers.certs_generate_command_message
     elsif Kafo::Helpers.module_enabled?(@kafo, 'katello_devel')
       Kafo::Helpers.dev_server_success_message(@kafo)
-      Kafo::Helpers.new_install_message(@kafo) if @kafo.param('foreman', 'authentication').value == true && new_install?
+      Kafo::Helpers.dev_new_install_message(@kafo) if new_install?
     end
 
     Kafo::Helpers.proxy_instructions_message(@kafo) if Kafo::Helpers.module_enabled?(@kafo, 'foreman_proxy_certs')


### PR DESCRIPTION
The devel scenario doesn't use the foreman module so this always fails.

Replaces https://github.com/Katello/katello-installer/pull/599