### PR TITLE
Fixes #23345 - only call cleanup if we could initialize

### DIFF
--- a/bin/foreman-proxy-certs-generate
+++ b/bin/foreman-proxy-certs-generate
@@ -85,7 +85,7 @@ if $0 == __FILE__
     CONFIG_FILE = gen.config_file.path
     Kafo::KafoConfigure.run
   ensure
-    gen.cleanup
+    gen.cleanup if gen
   end
   Kafo::KafoConfigure.exit_code == 2 ? exit(0) : exit(Kafo::KafoConfigure.exit_code)
 end


### PR DESCRIPTION
otherwise the following error is raised

    $ foreman-proxy-certs-generate --help
    /usr/sbin/foreman-proxy-certs-generate:88:in `ensure in <main>': undefined method `cleanup' for nil:NilClass (NoMethodError)
	    from /usr/sbin/foreman-proxy-certs-generate:88:in `<main>'

and that masks the real error that happened in initialize