### PR TITLE
fixes #23375 - use db names from puppet params

### DIFF
--- a/hooks/pre/10-reset_feature.rb
+++ b/hooks/pre/10-reset_feature.rb
@@ -59,7 +59,7 @@ def empty_candlepin_database
   if remote_host?(config[:host])
     empty_database!(config)
   else
-    Kafo::Helpers.execute('sudo -u postgres dropdb candlepin')
+    Kafo::Helpers.execute("sudo -u postgres dropdb #{config[:database]}")
   end
 end
 
@@ -84,7 +84,7 @@ def empty_mongo
     Kafo::Helpers.execute(
       [
         'systemctl stop rh-mongodb34-mongod',
-        'rm -f /var/lib/mongodb/pulp_database*',
+        "rm -f /var/lib/mongodb/#{mongo_config[:database]}*",
         'systemctl start rh-mongodb34-mongod'
       ]
     )


### PR DESCRIPTION
To test, install a katello like this:

```
foreman-installer --scenario katello --katello-candlepin-db-name platypus --katello-pulp-db-name capybara
```

Run foreman-installer --reset with this PR, and notice it drops the correct databases.