### PR TITLE
Fixes #22598 - add check for key usage Key Encipherment

### DIFF
--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -145,6 +145,16 @@ function check-cert-san () {
     fi
 }
 
+function check-cert-usage-key-encipherment () {
+    printf "Checking Key Usage extension on certificate for Key Encipherment"
+    CHECK=$(openssl x509 -noout -text -in $CERT_FILE | grep -A1 'X509v3 Key Usage:' | grep 'Key Encipherment')
+    if [ $? == "0" ]; then
+        success
+    else
+        error 4 "The $CERT_FILE does not allow for the 'Digital Signature' key usage"
+    fi
+}
+
 check-server-cert-encoding
 check-expiration
 check-cert-ca-flag
@@ -152,6 +162,7 @@ show-details
 check-priv-key
 check-ca-bundle
 check-cert-san
+check-cert-usage-key-encipherment
 
 if [ $EXIT_CODE == "0" -a $CERT_HOSTNAME != $HOSTNAME ]; then
     cat <<EOF


### PR DESCRIPTION
I obtained a new server certificate for my Satellite server, but then found that yum couldn't fetch repository updates (errno 14, curl#60, NSS -8102, SEC_ERROR_INADEQUATE_KEY_USAGE). The certificate had X509v3 Key Usages of Digital Signature and Non Repudiation. When I got a new certificate which also included the Key Encipherment key usage, yum worked. (Red Hat Support case 02099325.)

This PR adds a check to katello-certs-check to ensure that the server certificate has the Key Encipherment key usage. With this patch, my old certificate fails katello-certs-check, and my new certificate passes.