### PR TITLE
Refs #15963 - katello-installer --help typos

### DIFF
--- a/hooks/boot/10-reset_hook.rb
+++ b/hooks/boot/10-reset_hook.rb
@@ -2,9 +2,9 @@
 app_option(
   '--reset',
   :flag,
-  "This option will drop the Katello database and clear all subsequent backend data stores." +
-  "You will lose all data! Unfortunately we\n" +
-  "can't detect a failure at the moment so you should verify the success\n" +
-  'manually. e.g. dropping can fail when DB is currently in use.',
+  'This option will drop the Katello database and clear all subsequent backend data stores. ' +
+  "You will lose all data!\nUnfortunately, we " +
+  "can't detect a failure, so you should verify success " +
+  "manually.\nDropping can fail when the DB is in use.",
   :default => false
 )


### PR DESCRIPTION
Hi,

This is one of a series of patches to address typos in `katello-installer --help` [#15963](http://projects.theforeman.org/issues/15963)

This diff addresses the `--reset` parameter's description, changing it from:

~~~
   --reset                       This option will drop the Katello database and clear all subsequent backend data stores.You will lose all data! Unfortunately we
                                 can't detect a failure at the moment so you should verify the success
                                 manually. e.g. dropping can fail when DB is currently in use. (default: false)
~~~
To:
~~~
   --reset                       This option will drop the Katello database and clear all subsequent backend data stores. You will lose all data!
                                 Unfortunately, we can't detect a failure, so you should verify success manually.
                                 Dropping can fail when the DB is in use. (default: false)
~~~

Thanks in advance!