### PR TITLE
Refs #23978 - Fix mongodb fact regression

### DIFF
--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -47,7 +47,7 @@ FORGE
       puppetlabs-stdlib (< 5.0.0, >= 4.13.0)
     puppet-extlib (2.0.1)
       puppetlabs-stdlib (< 5.0.0, >= 4.6.0)
-    puppet-mongodb (2.2.0)
+    puppet-mongodb (2.2.1)
       puppetlabs-apt (< 5.0.0, >= 2.1.0)
       puppetlabs-stdlib (< 5.0.0, >= 4.13.0)
     puppet-staging (3.2.0)


### PR DESCRIPTION
In puppet-mongodb 2.2.0 the mongodb_is_master fact was changed to ignore
a missing config file but introduced a regression when the fact was
used. In 2.2.1 this has been fixed.