### PR TITLE
Refs #24066 - Update Rubocop method length cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,3 +35,6 @@ Performance/Casecmp:
 
 Style/RescueModifier:
   Enabled: false
+
+Metrics/MethodLength:
+  Max: 40

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -40,11 +40,6 @@ Metrics/BlockNesting:
 Metrics/LineLength:
   Max: 263
 
-# Offense count: 3
-# Configuration parameters: CountComments.
-Metrics/MethodLength:
-  Max: 13
-
 # Offense count: 1
 # Cop supports --auto-correct.
 Performance/StartWith:

--- a/bin/foreman-proxy-certs-generate
+++ b/bin/foreman-proxy-certs-generate
@@ -20,7 +20,6 @@ class ForemanProxyCertsGenerate
 
   private
 
-  # rubocop: disable Metrics/MethodLength
   # rubocop: disable Naming/HeredocDelimiterNaming
   # rubocop: disable Lint/RescueWithoutErrorClass
   def generate_answers_file


### PR DESCRIPTION
Allow longer method length for MongoDB Engine Upgrade