### PR TITLE
Fixes #18806 - Never manage the Puppet group

### DIFF
--- a/config/foreman-proxy-content-answers.yaml
+++ b/config/foreman-proxy-content-answers.yaml
@@ -22,6 +22,7 @@ foreman_proxy:
   foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
   foreman_ssl_key: /etc/foreman-proxy/foreman_ssl_key.pem
   use_autosignfile: true
+  manage_puppet_group: false
 foreman_proxy::plugin::pulp:
   enabled: false
   pulpnode_enabled: true

--- a/config/foreman-proxy-content.migrations/180813131441-unmanage-puppet-group.rb
+++ b/config/foreman-proxy-content.migrations/180813131441-unmanage-puppet-group.rb
@@ -1,0 +1,5 @@
+if answers['foreman_proxy'].is_a?(Hash)
+  answers['foreman_proxy']['manage_puppet_group'] = false
+elsif answers['foreman_proxy'] == true
+  answers['foreman_proxy'] = {'manage_puppet_group' => false}
+end

--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -52,6 +52,7 @@ foreman_proxy:
   foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
   foreman_ssl_key: /etc/foreman-proxy/foreman_ssl_key.pem
   use_autosignfile: true
+  manage_puppet_group: false
 foreman_proxy::plugin::pulp:
   enabled: true
   pulpnode_enabled: false

--- a/config/katello.migrations/180813131441-unmanage-puppet-group.rb
+++ b/config/katello.migrations/180813131441-unmanage-puppet-group.rb
@@ -1,0 +1,5 @@
+if answers['foreman_proxy'].is_a?(Hash)
+  answers['foreman_proxy']['manage_puppet_group'] = false
+elsif answers['foreman_proxy'] == true
+  answers['foreman_proxy'] = {'manage_puppet_group' => false}
+end


### PR DESCRIPTION
This is a workaround when using the Puppet certificates but not managing Puppet. In the Katello context we never do that and it can result in a duplicate file declaration.