### PR TITLE
Fixes #24632 - cert-req needs to be removed

### DIFF
--- a/hooks/pre/20-certs_update.rb
+++ b/hooks/pre/20-certs_update.rb
@@ -22,7 +22,6 @@ end
 ca_file   = param('certs', 'server_ca_cert').value
 cert_file = param('certs', 'server_cert').value
 key_file  = param('certs', 'server_key').value
-req_file  = param('certs', 'server_cert_req').value
 
 if app_value('certs_update_server_ca') && !Kafo::Helpers.module_enabled?(@kafo, 'katello')
   error "--certs-update-server-ca needs to be used with katello"
@@ -56,7 +55,7 @@ end
 if !app_value('certs_skip_check') &&
        cert_file.to_s != "" &&
        (app_value('certs_update_server_ca') || app_value('certs_update_server'))
-  check_cmd = %{#{CHECK_SCRIPT} -c "#{cert_file}" -r "#{req_file}" -k "#{key_file}" -b "#{ca_file}"}
+  check_cmd = %{#{CHECK_SCRIPT} -c "#{cert_file}" -k "#{key_file}" -b "#{ca_file}"}
   output = `#{check_cmd} 2>&1`
   unless $?.success?
     error "Command '#{check_cmd}' exited with #{$?.exitstatus}:\n #{output}"
@@ -66,6 +65,5 @@ end
 if app_value('certs_reset') && !app_value(:noop)
   param('certs', 'server_cert').unset_value
   param('certs', 'server_key').unset_value
-  param('certs', 'server_cert_req').unset_value
   param('certs', 'server_ca_cert').unset_value
 end


### PR DESCRIPTION
Now katello-certs-check command does not accept -r ( request file) so this option should be removed from the 20-certs_update.rb hook. 