### PR TITLE
Fixes #24632 - Stop passing in -r to katello-certs-check

### DIFF
--- a/hooks/pre/20-certs_update.rb
+++ b/hooks/pre/20-certs_update.rb
@@ -22,7 +22,6 @@ end
 ca_file   = param('certs', 'server_ca_cert').value
 cert_file = param('certs', 'server_cert').value
 key_file  = param('certs', 'server_key').value
-req_file  = param('certs', 'server_cert_req').value
 
 if app_value('certs_update_server_ca') && !Kafo::Helpers.module_enabled?(@kafo, 'katello')
   error "--certs-update-server-ca needs to be used with katello"
@@ -56,7 +55,7 @@ end
 if !app_value('certs_skip_check') &&
        cert_file.to_s != "" &&
        (app_value('certs_update_server_ca') || app_value('certs_update_server'))
-  check_cmd = %{#{CHECK_SCRIPT} -c "#{cert_file}" -r "#{req_file}" -k "#{key_file}" -b "#{ca_file}"}
+  check_cmd = %{#{CHECK_SCRIPT} -c "#{cert_file}" -k "#{key_file}" -b "#{ca_file}"}
   output = `#{check_cmd} 2>&1`
   unless $?.success?
     error "Command '#{check_cmd}' exited with #{$?.exitstatus}:\n #{output}"


### PR DESCRIPTION
35722703f8252ab835b6f5bfd8be04ce4d547465 removed the -r option so we should stop passing it in.