### PR TITLE
Fixes #25061 - Remove EL6 compat in reset_candlepin

### DIFF
--- a/hooks/pre/10-reset_feature.rb
+++ b/hooks/pre/10-reset_feature.rb
@@ -65,12 +65,10 @@ end
 
 def reset_candlepin
   Kafo::KafoConfigure.logger.info 'Dropping Candlepin database!'
-
-  tomcat = File.exists?('/var/lib/tomcat') ? 'tomcat' : 'tomcat6'
   commands = [
     'rm -f /var/lib/candlepin/cpdb_done',
     'rm -f /var/lib/candlepin/cpinit_done',
-    "service #{tomcat} stop"
+    'systemctl stop tomcat'
   ]
   Kafo::Helpers.execute(commands)
   empty_candlepin_database


### PR DESCRIPTION
In EL6 the service was named tomcat6. The hook autodetects this but since we only support EL7 we can hardcode it. We can also move to systemctl instead of service.