### PR TITLE
Refs #12386 - Let qdrouterd listen on IPv6

### DIFF
--- a/config/foreman-proxy-content.migrations/181012141418-qdrouterd-listen-ipv6.rb
+++ b/config/foreman-proxy-content.migrations/181012141418-qdrouterd-listen-ipv6.rb
@@ -1,0 +1,6 @@
+mod = answers['foreman_proxy_content']
+if mod.is_a?(Hash)
+  ['qpid_router_agent_addr', 'qpid_router_hub_addr'].each do |var|
+    mod.delete(var) if mod[var] == '0.0.0.0'
+  end
+end

--- a/config/katello.migrations/181012141418-qdrouterd-listen-ipv6.rb
+++ b/config/katello.migrations/181012141418-qdrouterd-listen-ipv6.rb
@@ -1,0 +1,6 @@
+mod = answers['foreman_proxy_content']
+if mod.is_a?(Hash)
+  ['qpid_router_agent_addr', 'qpid_router_hub_addr'].each do |var|
+    mod.delete(var) if mod[var] == '0.0.0.0'
+  end
+end


### PR DESCRIPTION
The defaults in puppet-foreman_proxy_content changed and this reflects that change for existing users.