### PR TITLE
Fixes #25306 - Add space after command output in kcc

### DIFF
--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -171,17 +171,17 @@ if [ $EXIT_CODE == "0" -a $CERT_HOSTNAME == $HOSTNAME ]; then
 
 To install the Katello main server with the custom certificates, run:
 
-    foreman-installer --scenario katello\\
-                      --certs-server-cert "$(readlink -f $CERT_FILE)"\\
-                      --certs-server-key "$(readlink -f $KEY_FILE)"\\
+    foreman-installer --scenario katello \\
+                      --certs-server-cert "$(readlink -f $CERT_FILE)" \\
+                      --certs-server-key "$(readlink -f $KEY_FILE)" \\
                       --certs-server-ca-cert "$(readlink -f $CA_BUNDLE_FILE)"
 
 To update the certificates on a currently running Katello installation, run:
 
-    foreman-installer --scenario katello\\
-                      --certs-server-cert "$(readlink -f $CERT_FILE)"\\
-                      --certs-server-key "$(readlink -f $KEY_FILE)"\\
-                      --certs-server-ca-cert "$(readlink -f $CA_BUNDLE_FILE)"\\
+    foreman-installer --scenario katello \\
+                      --certs-server-cert "$(readlink -f $CERT_FILE)" \\
+                      --certs-server-key "$(readlink -f $KEY_FILE)" \\
+                      --certs-server-ca-cert "$(readlink -f $CA_BUNDLE_FILE)" \\
                       --certs-update-server --certs-update-server-ca
 EOF
 elif [ $EXIT_CODE == "0" ]; then
@@ -190,19 +190,19 @@ elif [ $EXIT_CODE == "0" ]; then
 
   To use them inside a NEW \$FOREMAN_PROXY, run this command:
 
-      foreman-proxy-certs-generate --foreman-proxy-fqdn "\$FOREMAN_PROXY"\\
-                                   --certs-tar  "~/\$FOREMAN_PROXY-certs.tar"\\
-                                   --server-cert "$(readlink -f $CERT_FILE)"\\
-                                   --server-key "$(readlink -f $KEY_FILE)"\\
-                                   --server-ca-cert "$(readlink -f $CA_BUNDLE_FILE)"\\
+      foreman-proxy-certs-generate --foreman-proxy-fqdn "\$FOREMAN_PROXY" \\
+                                   --certs-tar  "~/\$FOREMAN_PROXY-certs.tar" \\
+                                   --server-cert "$(readlink -f $CERT_FILE)" \\
+                                   --server-key "$(readlink -f $KEY_FILE)" \\
+                                   --server-ca-cert "$(readlink -f $CA_BUNDLE_FILE)" \\
 
   To use them inside an EXISTING \$FOREMAN_PROXY, run this command INSTEAD:
 
-      foreman-proxy-certs-generate --foreman-proxy-fqdn "\$FOREMAN_PROXY"\\
-                                   --certs-tar  "~/\$FOREMAN_PROXY-certs.tar"\\
-                                   --server-cert "$(readlink -f $CERT_FILE)"\\
-                                   --server-key "$(readlink -f $KEY_FILE)"\\
-                                   --server-ca-cert "$(readlink -f $CA_BUNDLE_FILE)"\\
+      foreman-proxy-certs-generate --foreman-proxy-fqdn "\$FOREMAN_PROXY" \\
+                                   --certs-tar  "~/\$FOREMAN_PROXY-certs.tar" \\
+                                   --server-cert "$(readlink -f $CERT_FILE)" \\
+                                   --server-key "$(readlink -f $KEY_FILE)" \\
+                                   --server-ca-cert "$(readlink -f $CA_BUNDLE_FILE)" \\
                                    --certs-update-server
 EOF
 else


### PR DESCRIPTION
Results of testing:
~~~
Katello cert:

[root@satellite1 ~]# ./katello-certs-check -b /root/ca.pem -k /root/server.key -c /root/server.crt 
Checking server certificate encoding: 
[OK]

Checking expiration of certificate: 
[OK]

Checking expiration of CA bundle: 
[OK]

Checking if server certificate has CA:TRUE flag 
[OK]

Checking to see if the private key matches the certificate: 
[OK]

Checking CA bundle against the certificate file: 
[OK]

Checking Subject Alt Name on certificate 
[OK]

Checking Key Usage extension on certificate for Key Encipherment 
[OK]

Validation succeeded


To install the Katello main server with the custom certificates, run:

    foreman-installer --scenario katello \
                      --certs-server-cert "/root/server.crt" \
                      --certs-server-key "/root/server.key" \
                      --certs-server-ca-cert "/root/ca.pem"

To update the certificates on a currently running Katello installation, run:

    foreman-installer --scenario katello \
                      --certs-server-cert "/root/server.crt" \
                      --certs-server-key "/root/server.key" \
                      --certs-server-ca-cert "/root/ca.pem" \
                      --certs-update-server --certs-update-server-ca
					  
Capsule Cert:

[root@satellite1 ~]# ./katello-certs-check -b /root/ca.pem -k /root/capsule_certs/server.key -c /root/capsule_certs/server.crt 
Checking server certificate encoding: 
[OK]

Checking expiration of certificate: 
[OK]

Checking expiration of CA bundle: 
[OK]

Checking if server certificate has CA:TRUE flag 
[OK]

Checking to see if the private key matches the certificate: 
[OK]

Checking CA bundle against the certificate file: 
[OK]

Checking Subject Alt Name on certificate 
[OK]

Checking Key Usage extension on certificate for Key Encipherment 
[OK]

Validation succeeded


  To use them inside a NEW $FOREMAN_PROXY, run this command:

      foreman-proxy-certs-generate --foreman-proxy-fqdn "$FOREMAN_PROXY" \
                                   --certs-tar  "~/$FOREMAN_PROXY-certs.tar" \
                                   --server-cert "/root/capsule_certs/server.crt" \
                                   --server-key "/root/capsule_certs/server.key" \
                                   --server-ca-cert "/root/ca.pem" \

  To use them inside an EXISTING $FOREMAN_PROXY, run this command INSTEAD:

      foreman-proxy-certs-generate --foreman-proxy-fqdn "$FOREMAN_PROXY" \
                                   --certs-tar  "~/$FOREMAN_PROXY-certs.tar" \
                                   --server-cert "/root/capsule_certs/server.crt" \
                                   --server-key "/root/capsule_certs/server.key" \
                                   --server-ca-cert "/root/ca.pem" \
                                   --certs-update-server
~~~