### PR TITLE
Fixes #25386 - Use the module_enabled? helper

### DIFF
--- a/hooks/post/30-upgrade.rb
+++ b/hooks/post/30-upgrade.rb
@@ -42,7 +42,7 @@ end
 
 if app_value(:upgrade)
   if [0, 2].include?(@kafo.exit_code)
-    upgrade_tasks if module_enabled?('foreman')
+    upgrade_tasks if Kafo::Helpers.module_enabled?(@kafo, 'foreman')
     Kafo::Helpers.log_and_say :info, 'Upgrade completed!'
   else
     Kafo::Helpers.log_and_say :error, 'Upgrade failed during the installation phase. Fix the error and re-run the upgrade.'


### PR DESCRIPTION
In kafo 2.1.0 the module_enabled? hook function doesn't handle the case where a module isn't present at all. The Kafo::Helpers version of it does.

(cherry picked from commit 7211b9321cc340fd61e76ee862004e42e7666ef6)

See https://github.com/Katello/katello-installer/pull/712 as well