### PR TITLE
Fixes #25563 - Remove default_values_dir from configs

### DIFF
--- a/bin/foreman-proxy-certs-generate
+++ b/bin/foreman-proxy-certs-generate
@@ -57,7 +57,6 @@ class ForemanProxyCertsGenerate
                   - "/usr/share/katello-installer-base/modules"
                 :hook_dirs: ["#{INSTALLER_DIR}/hooks"]
                 :parser_cache_path: '/usr/share/katello-installer-base/parser_cache/foreman-proxy-certs-generate.yaml'
-                :default_values_dir: /tmp
                 :dont_save_answers: true
                 :mapping:
                   :foreman_proxy_certs:

--- a/config/foreman-proxy-content.yaml
+++ b/config/foreman-proxy-content.yaml
@@ -7,7 +7,6 @@
 :no_prefix: false
 :answer_file: ./config/foreman-proxy-content-answers.yaml
 :installer_dir: .
-:default_values_dir: /tmp
 :module_dirs:
 - ./_build/modules
 - ../katello-installer/modules

--- a/config/katello.yaml
+++ b/config/katello.yaml
@@ -7,7 +7,6 @@
 :no_prefix: false
 :answer_file: ./config/katello-answers.yaml
 :installer_dir: .
-:default_values_dir: ./config
 :module_dirs:
 - ./_build/modules
 - ../katello-installer/modules


### PR DESCRIPTION
Since kafo 1.0.7 this option isn't read anymore so it can be removed from the configs.