### PR TITLE
Fixes #25564 - Generates proper output

### DIFF
--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -55,8 +55,6 @@ if [[ $TARGET != "foreman" && $TARGET != "foreman-proxy" ]]; then
     exit 1
 fi
 
-HOSTNAME=$(hostname -f)
-CERT_HOSTNAME=$(openssl x509 -noout -subject -in $CERT_FILE | sed -e 's/^subject.*CN=\([a-zA-Z0-9\.\-]*\).*$/\1/')
 
 function error () {
     echo -e "\n${RED}[FAIL]${RESET}\n"

--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -11,12 +11,16 @@ function usage () {
 Verifies, that custom SSL certificate files are usable
 as part of the Katello installation. When passing filenames use absolute paths.
 
-usage: $0 -c CERT_FILE -k KEY_FILE -b CA_BUNDLE_FILE
+usage: $0 -t TARGET -c CERT_FILE -k KEY_FILE -b CA_BUNDLE_FILE
 HELP
 }
 
-while getopts "c:k:b:" opt; do
+while getopts "t:c:k:b:" opt; do
     case $opt in
+        t)
+	    TARGET=$OPTARG
+            ;;
+
         c)
             CERT_FILE="$(readlink -f $OPTARG)"
             ;;
@@ -41,6 +45,12 @@ EXIT_CODE=0
 
 if [ -z "$CERT_FILE" -o -z "$KEY_FILE" -o -z "$CA_BUNDLE_FILE" ]; then
     echo 'One of the required parameters is missing.' >&2
+    usage
+    exit 1
+fi
+
+if [[ $TARGET != "foreman" && $TARGET != "foreman-proxy" ]]; then
+    echo 'Target not specified or incorrect. Target value should be foreman or foreman-proxy' >&2
     usage
     exit 1
 fi
@@ -165,7 +175,7 @@ check-ca-bundle
 check-cert-san
 check-cert-usage-key-encipherment
 
-if [ $EXIT_CODE == "0" -a $CERT_HOSTNAME == $HOSTNAME ]; then
+if [ $EXIT_CODE == "0" -a "$TARGET" == "foreman" ]; then
     echo -e "${GREEN}Validation succeeded${RESET}\n"
     cat <<EOF
 
@@ -184,7 +194,7 @@ To update the certificates on a currently running Katello installation, run:
                       --certs-server-ca-cert "$(readlink -f $CA_BUNDLE_FILE)" \\
                       --certs-update-server --certs-update-server-ca
 EOF
-elif [ $EXIT_CODE == "0" ]; then
+elif [ $EXIT_CODE == "0"  -a "$TARGET" == "foreman-proxy" ]; then
   echo -e "${GREEN}Validation succeeded${RESET}\n"
   cat <<EOF
 


### PR DESCRIPTION
This issue was caused because the fix in the following RFE.

[RFE] katello-certs-check to distinguish between Satellite and Capsule
https://projects.theforeman.org/issues/22694

Code snippet

```
HOSTNAME=$(hostname -f)
CERT_HOSTNAME=$(openssl x509 -noout -subject -in $CERT_FILE | sed -e 's/^subject.*CN=\([a-zA-Z0-9\.\-]*\).*$/\1/')

if [ $EXIT_CODE == "0" -a $CERT_HOSTNAME == $HOSTNAME ]; then
echo -e "${GREEN}Validation succeeded${RESET}\n"
    cat <<EOF

To install the Katello main server with the custom certificates, run:

    satellite-installer --scenario satellite\\
                      --certs-server-cert "$(readlink -f $CERT_FILE)"\\
                      --certs-server-key "$(readlink -f $KEY_FILE)"\\
                      --certs-server-ca-cert "$(readlink -f $CA_BUNDLE_FILE)"

```
Issue is we are checking the hostname against the cert CN and in case of wildcard cert CN is *.example.com. So this condition fails in case of wildcard certs that are to be installed in the satellite server.

Need to modify the logic, better to give the user the ability to define target for which cert to be generated.
```
katello-certs-check -t foreman -c /customcerts/cert_crt.pem -k /customcerts/cert_key.pem -b /customcerts/CA_crt.pem
```