### PR TITLE
Fixes #25665 - Use the bash comparisons can function calls

### DIFF
--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -66,11 +66,11 @@ function warning () {
 function check-server-cert-encoding () {
     printf 'Checking server certificate encoding: '
     openssl x509 -inform pem -in $CERT_FILE -noout -text &> /dev/null
-    if [ $? == "0" ]; then
+    if [[ $? == "0" ]]; then
         success
     else
         openssl x509 -inform der -in $CERT_FILE -noout -text &> /dev/null
-        if [ $? == "0" ]; then
+        if [[ $? == "0" ]]; then
             error 8 "The server certificate is in DER encoding, which is incompatible.\n\n"
             printf "Run the following command to convert the certificate to PEM encoding,\n"
             printf "then test it again.\n"
@@ -87,17 +87,17 @@ function check-expiration () {
     DATE=$(date -u +"%b %-d %R:%S %Y")
     CERT_EXP=$(openssl x509 -noout -enddate -in $CERT_FILE | sed -e 's/notAfter=//' | awk '{$NF="";}1')
     CA_EXP=$(openssl x509 -noout -enddate -in $CA_BUNDLE_FILE | sed -e 's/notAfter=//' | awk '{$NF="";}1')
-    DATE_TODAY=`date -d"${DATE}" +%Y%m%d%H%M%S`
-    CERT_DATE=`date -d"${CERT_EXP}" +%Y%m%d%H%M%S`
-    CA_DATE=`date -d"${CA_EXP}" +%Y%m%d%H%M%S`
+    DATE_TODAY=$(date -d"${DATE}" +%Y%m%d%H%M%S)
+    CERT_DATE=$(date -d"${CERT_EXP}" +%Y%m%d%H%M%S)
+    CA_DATE=$(date -d"${CA_EXP}" +%Y%m%d%H%M%S)
     printf "Checking expiration of certificate: "
-    if [ $DATE_TODAY -gt $CERT_DATE ]; then
+    if [[ $DATE_TODAY -gt $CERT_DATE ]]; then
         error 6 "The certificate \"$CERT_FILE\" has already expired on: $CERT_EXP"
     else
         success
     fi
     printf "Checking expiration of CA bundle: "
-    if [ $DATE_TODAY -gt $CA_DATE ]; then
+    if [[ $DATE_TODAY -gt $CA_DATE ]]; then
         error 7 "The CA bundle \"$CA_BUNDLE_FILE\" has already expired on: $CA_EXP"
     else
         success
@@ -107,7 +107,7 @@ function check-expiration () {
 function check-cert-ca-flag () {
     printf "Checking if server certificate has CA:TRUE flag "
     openssl x509 -in $CERT_FILE -noout -text | grep -q CA:TRUE
-    if [ $? -ne 0 ]; then
+    if [[ $? -ne 0 ]]; then
         success
     else
         error 7 "The server certificate is marked as a CA and can not be used."
@@ -118,7 +118,7 @@ function check-priv-key () {
     printf "Checking to see if the private key matches the certificate: "
     CERT_MOD=$(openssl x509 -noout -modulus -in $CERT_FILE)
     KEY_MOD=$(openssl rsa -noout -modulus -in $KEY_FILE)
-    if [ "$CERT_MOD" != "$KEY_MOD" ]; then
+    if [[ "$CERT_MOD" != "$KEY_MOD" ]]; then
         error 2 "The $KEY_FILE does not match the $CERT_FILE"
     else
         success
@@ -128,7 +128,7 @@ function check-priv-key () {
 function check-ca-bundle () {
     printf "Checking CA bundle against the certificate file: "
     CHECK=$(openssl verify -CAfile $CA_BUNDLE_FILE -purpose sslserver -verbose $CERT_FILE 2>&1)
-    if [ $? == "0" ]; then
+    if [[ $? == "0" ]]; then
         success
     else
         error 4  "The $CA_BUNDLE_FILE does not verify the $CERT_FILE"
@@ -139,7 +139,7 @@ function check-ca-bundle () {
 function check-cert-san () {
     printf "Checking Subject Alt Name on certificate "
     CHECK=$(openssl x509 -noout -text -in $CERT_FILE | grep DNS:)
-    if [ $? == "0" ]; then
+    if [[ $? == "0" ]]; then
         success
     else
         warning
@@ -150,7 +150,7 @@ function check-cert-san () {
 function check-cert-usage-key-encipherment () {
     printf "Checking Key Usage extension on certificate for Key Encipherment "
     CHECK=$(openssl x509 -noout -text -in $CERT_FILE | grep -A1 'X509v3 Key Usage:' | grep 'Key Encipherment')
-    if [ $? == "0" ]; then
+    if [[ $? == "0" ]]; then
         success
     else
         error 4 "The $CERT_FILE does not allow for the 'Digital Signature' key usage."
@@ -165,7 +165,7 @@ check-ca-bundle
 check-cert-san
 check-cert-usage-key-encipherment
 
-if [ $EXIT_CODE == "0" -a $CERT_HOSTNAME == $HOSTNAME ]; then
+if [[ $EXIT_CODE == "0" ]] && [[ $CERT_HOSTNAME == $HOSTNAME ]]; then
     echo -e "${GREEN}Validation succeeded${RESET}\n"
     cat <<EOF
 
@@ -184,7 +184,7 @@ To update the certificates on a currently running Katello installation, run:
                       --certs-server-ca-cert "$(readlink -f $CA_BUNDLE_FILE)" \\
                       --certs-update-server --certs-update-server-ca
 EOF
-elif [ $EXIT_CODE == "0" ]; then
+elif [[ $EXIT_CODE == "0" ]]; then
   echo -e "${GREEN}Validation succeeded${RESET}\n"
   cat <<EOF
 


### PR DESCRIPTION
The use of == is a bash-only feature. Since we're using this already, we might as well go all the way and use the safer [[ ]] checks.

Using $() instead of `` is also a better practice because it allows nesting and slightly easier to read.